### PR TITLE
Bosky/integration api with langchain

### DIFF
--- a/ORCHESTRATION.md
+++ b/ORCHESTRATION.md
@@ -1,29 +1,22 @@
 # ORCHESTRATION — ED Triage AI
 
-> **Last updated:** 2026-04-01
-> **Status:** Backend + frontend integrated with live SageMaker endpoint. LangGraph + RAG orchestration pending.
+> **Last updated:** 2026-04-02
+> **Status:** Fully integrated. Streamlit frontend → FastAPI backend → LangGraph agentic pipeline (SageMaker + Pinecone RAG + Bedrock LLM).
 
 ---
 
 ## System Overview
 
-**TriagePulse** is an Emergency Department triage assistant. The system currently consists of:
+**TriagePulse** is an Emergency Department triage assistant. The system consists of:
 
-1. **Streamlit Frontend** (`frontend/app.py`) — Collects patient triage notes and vitals, sends them to the backend, and displays the prediction results.
-2. **FastAPI Backend** (`backend/`) — Receives requests from the frontend, calls the orchestration service, and returns the result to the frontend.
-3. **SageMaker Endpoint** (`edtriage-live`) — Hosts the trained arch4 model (BioClinicalBERT + LightGBM fusion). Deployed and live.
+1. **Streamlit Frontend** (`frontend/app.py`) — Collects patient demographics, triage notes, and vitals. Displays enriched prediction results including triage priority, clinical reasoning, key SHAP factors, similar historical cases, and a technical details card.
+2. **FastAPI Backend** (`backend/`) — Receives requests from the frontend, runs the full inference pipeline via `run_triage_inference`, and returns an enriched `TriageResponse`.
+3. **LangGraph Agentic Pipeline** (`src/agents/`) — Orchestrates the full inference pipeline: SageMaker prediction + Pinecone RAG retrieval (parallel) → LLM clinical analysis → reconciliation/synthesis.
+4. **SageMaker Endpoint** (`edtriage-live`) — Hosts the arch4 model (BioClinicalBERT + LightGBM fusion).
+5. **Pinecone RAG** (`src/retreival/`) — Retrieves top-5 similar historical cases using Bedrock Titan embeddings against the `ed-triage-cases` index.
+6. **Bedrock LLM** — Claude Sonnet (`claude-sonnet-4-6`) provides independent ESI assessment and clinical rationale.
 
 ### Current Data Flow
-
-```
-┌─────────────┐    POST /predict    ┌─────────────┐   InvokeEndpoint   ┌────────────┐
-│  Streamlit   │ ─────────────────► │   FastAPI    │ ─────────────────► │ SageMaker  │
-│  Frontend    │ ◄───────────────── │   Backend    │ ◄───────────────── │  edtriage  │
-│  :8501       │   TriageResponse   │  :8000       │   raw JSON         │   -live    │
-└─────────────┘                     └─────────────┘                     └────────────┘
-```
-
-### Target Data Flow (after LangGraph integration)
 
 ```
 ┌─────────────┐    POST /predict    ┌─────────────┐
@@ -31,17 +24,23 @@
 │  Frontend    │ ◄───────────────── │   Backend    │
 │  :8501       │   TriageResponse   │  :8000       │
 └─────────────┘                     └──────┬───────┘
-                                           │
+                                           │ run_triage_inference()
                                            ▼
-                                  ┌─────────────────┐
-                                  │  orchestration/  │  ◄─── NEW SERVICE
-                                  │                  │
-                                  │  Owns the full   │ ──► SageMaker (edtriage-live)
-                                  │  inference       │ ──► LangGraph + RAG (Pinecone)
-                                  │  pipeline        │ ──► Claude via Bedrock
-                                  └─────────────────┘
+                                  ┌─────────────────────────────┐
+                                  │   LangGraph triage_graph     │
+                                  │                              │
+                                  │  predict_node ──┐            │
+                                  │  (SageMaker)    ├──► analyze_node (Claude)
+                                  │  retrieve_node ─┘        │   │
+                                  │  (Pinecone RAG)           ▼   │
+                                  │                    synthesize_node
+                                  │                    (reconciliation)
+                                  └─────────────────────────────┘
 ```
 
+- `predict_node` and `retrieve_node` run in **parallel** (fan-out from START).
+- `analyze_node` fans in both results and calls Claude via Bedrock.
+- `synthesize_node` deterministically reconciles model vs LLM recommendation (always takes the more cautious of the two).
 - **State management:** `st.session_state` on the frontend. No database. No backend file storage.
 - **Patient history:** Stored in `st.session_state` for the duration of the browser session only.
 
@@ -54,10 +53,19 @@ ed_triage_ai/
 ├── ORCHESTRATION.md              # THIS FILE — single source of truth
 ├── Makefile                      # Endpoint lifecycle commands (deploy / delete)
 ├── backend/                      # FastAPI service
-├── orchestration/                # Inference orchestration service (PENDING — to be created)
+│   ├── main.py                   # /health and /predict routes
+│   ├── schemas.py                # TriageRequest + TriageResponse (enriched)
+│   ├── config.py                 # pydantic-settings (env vars)
+│   └── sagemaker_service.py      # run_triage_inference — pipeline entry point
 ├── frontend/                     # Streamlit UI
-├── src/agents/                   # LangGraph graph + nodes (to be consumed by orchestration/)
-├── src/retreival/                # Pinecone RAG (to be consumed by orchestration/)
+│   └── app.py                    # Intake form + results page
+├── src/agents/                   # LangGraph graph + nodes
+│   ├── graph.py                  # triage_graph definition
+│   ├── nodes.py                  # predict_node, retrieve_node, analyze_node, synthesize_node
+│   ├── state.py                  # TriageState TypedDict
+│   └── prompts.py                # LLM prompt templates
+├── src/retreival/                # Pinecone RAG
+│   └── retrieval.py              # EDTriageRAG — embed + search + format
 └── sagemaker/                    # ML training pipeline (DO NOT MODIFY)
 ```
 
@@ -76,7 +84,7 @@ ed_triage_ai/
 
 ### `POST /predict`
 
-Accepts triage data from the frontend, runs the inference pipeline, returns a prediction.
+Accepts triage data from the frontend, runs the full agentic pipeline, returns an enriched prediction.
 
 #### Request Body (`TriageRequest`)
 
@@ -85,6 +93,7 @@ Accepts triage data from the frontend, runs the inference pipeline, returns a pr
 | `model`             | `str`           | No       | `"arch4"`    | Which model architecture to invoke              |
 | `triage_notes`      | `str`           | **Yes**  | —            | Free-text clinical notes from the UI            |
 | `age`               | `int \| None`   | No       | `None`       | Patient age in years                            |
+| `sex`               | `str \| None`   | No       | `None`       | Female, Male, or Other                          |
 | `heart_rate`        | `int \| None`   | No       | `None`       | BPM                                             |
 | `resp_rate`         | `int \| None`   | No       | `None`       | Breaths per minute                              |
 | `sbp`               | `int \| None`   | No       | `None`       | Systolic blood pressure (mmHg)                  |
@@ -97,77 +106,80 @@ Accepts triage data from the frontend, runs the inference pipeline, returns a pr
 **Example request:**
 ```json
 {
-  "triage_notes": "54M presenting with acute chest pain radiating to left arm. Diaphoretic.",
-  "age": 54,
-  "heart_rate": 132,
-  "resp_rate": 22,
+  "triage_notes": "68F presenting with fever, confusion, and low blood pressure for 6 hours.",
+  "age": 68,
+  "sex": "Female",
+  "heart_rate": 118,
+  "resp_rate": 24,
   "sbp": 88,
   "dbp": 52,
-  "spo2": 84,
-  "temp_f": 98.6,
-  "pain": 8,
+  "spo2": 93,
+  "temp_f": 101.8,
+  "pain": 6,
   "arrival_transport": "Ambulance"
 }
 ```
 
 #### Response Body (`TriageResponse`)
 
-| Field             | Type               | Notes                                                        |
-|-------------------|--------------------|--------------------------------------------------------------|
-| `predicted_class` | `int`              | 0=L1-Critical, 1=L2-Emergent, 2=L3-Urgent/LessUrgent        |
-| `predicted_label` | `str`              | `"L1-Critical"`, `"L2-Emergent"`, `"L3-Urgent/LessUrgent"`  |
-| `probabilities`   | `dict[str, float]` | Confidence per class                                         |
-| `top_features`    | `list[dict]`       | Top 5 SHAP drivers: `{feature, shap, direction}`             |
-| `safety_flag`     | `bool`             | True if clinical scores conflict with prediction             |
-| `safety_reason`   | `str \| None`      | Human-readable explanation if flagged                        |
-| `model_used`      | `str`              | Which model produced this result                             |
-
-> **Note:** The response schema will be extended when LangGraph orchestration is added (see below).
+| Field                | Type               | Notes                                                        |
+|----------------------|--------------------|--------------------------------------------------------------|
+| `predicted_class`    | `int`              | 0=L1-Critical, 1=L2-Emergent, 2=L3-Urgent/LessUrgent        |
+| `predicted_label`    | `str`              | `"L1-Critical"`, `"L2-Emergent"`, `"L3-Urgent/LessUrgent"`  |
+| `probabilities`      | `dict[str, float]` | Confidence per class                                         |
+| `top_features`       | `list[dict]`       | Top 5 SHAP drivers: `{feature, shap, direction}`             |
+| `safety_flag`        | `bool`             | True if clinical scores conflict with prediction             |
+| `safety_reason`      | `str \| None`      | Human-readable explanation if flagged                        |
+| `model_used`         | `str`              | Which model produced this result                             |
+| `reconciled_label`   | `str \| None`      | More cautious of model vs LLM recommendation                 |
+| `reconciled_class`   | `int \| None`      | 0-based class index for reconciled_label                     |
+| `llm_esi`            | `int \| None`      | LLM independent ESI recommendation (1/2/3)                   |
+| `llm_agreement`      | `bool \| None`     | True if LLM agrees with model prediction                     |
+| `clinical_rationale` | `str \| None`      | LLM clinical reasoning narrative                             |
+| `similar_cases`      | `list \| None`     | Top-5 RAG-retrieved historical cases with vitals + outcome   |
+| `flags`              | `list[str] \| None`| Escalation signals and uncertainty notes                     |
+| `confidence_pct`     | `int \| None`      | Model confidence 0–100                                       |
+| `uncertainty_flag`   | `bool \| None`     | True if confidence is below threshold                        |
 
 ---
 
 ## Backend (`backend/`)
 
-### Integration point for orchestration
+`run_triage_inference(request: TriageRequest)` in `sagemaker_service.py` is the pipeline entry point called by `POST /predict`. It:
 
-`backend/sagemaker_service.py` exposes `run_triage_inference(request: TriageRequest)` — the function called by `POST /predict`. Currently it calls the SageMaker endpoint directly.
+1. Transforms the request into a SageMaker payload via `transform_request()`
+2. Calls the SageMaker endpoint via `invoke_endpoint()`
+3. Maps the request to a `patient` dict via `_request_to_patient()`
+4. Invokes the LangGraph `triage_graph` with `{patient, prediction}` as input
+5. Shapes the `final_report` from the graph into the `TriageResponse` contract
 
-**When the orchestration service is ready, `run_triage_inference` is the only function that needs to change.** It will delegate to `orchestration/` instead of calling the endpoint directly.
+### Transformation helpers
 
-### Transformation helpers (remain in `backend/`)
-
-- `transform_request(request) -> dict` — converts `TriageRequest` to SageMaker payload format
-- `transform_response(response, model_used) -> dict` — converts raw endpoint response to `TriageResponse`
+- `transform_request(request) -> dict` — converts `TriageRequest` to SageMaker payload (renames `triage_notes` → `triage_text`, uppercases `arrival_transport`, drops Nones)
+- `transform_response(response, model_used) -> dict` — converts raw endpoint response to base `TriageResponse` fields
+- `_request_to_patient(request) -> dict` — maps `TriageRequest` to the patient dict shape the LangGraph graph expects
 
 ---
 
-## Orchestration Service (`orchestration/`) — Pending
+## LangGraph Pipeline (`src/agents/`)
 
-The `orchestration/` directory should be created as a sibling to `backend/`. It will own the full inference pipeline end-to-end: calling the SageMaker endpoint, running the LangGraph graph (RAG + LLM reasoning), and returning an enriched result.
+### Nodes
 
-`invoke_endpoint` (currently in `backend/sagemaker_service.py`) should move here, since endpoint invocation is part of the orchestration pipeline, not the HTTP layer.
+| Node | Input | Output | Notes |
+|------|-------|--------|-------|
+| `predict_node` | `patient`, `prediction` (raw SageMaker) | `model_output` | Normalises SageMaker response into a clean `model_output` dict |
+| `retrieve_node` | `patient` | `similar_cases`, `cases_text` | Embeds patient via Bedrock Titan, searches Pinecone `ed-triage-cases` top-5 |
+| `analyze_node` | `model_output`, `similar_cases`, `patient` | `llm_esi`, `llm_agreement`, `clinical_rationale` | Calls Claude Sonnet via Bedrock with structured prompt |
+| `synthesize_node` | all prior state | `final_report` | Deterministic reconciliation: `reconciled = min(model_class, llm_class)` |
 
-The backend calls into this service; the backend does not need to know about SageMaker, LangGraph, Pinecone, or Bedrock directly.
+`predict_node` and `retrieve_node` run in parallel; `analyze_node` fans in both.
 
-### External dependencies
+### Reconciliation logic
 
-| Service | Purpose |
-|---------|---------|
-| SageMaker (`edtriage-live`) | ML model inference |
-| AWS Bedrock (`claude-sonnet-4-6`) | LLM clinical reasoning |
-| AWS Bedrock (Titan embed) | Patient embedding for RAG |
-| Pinecone (`ed-triage-cases`) | Historical case vector search — API key in AWS Secrets Manager: `prod/pinecone/api_key` |
-
-### Enriched response fields (to be added to `TriageResponse`)
-
-When orchestration is complete, the response will include additional fields sourced from LangGraph:
-- Reconciled triage level (more cautious of model vs LLM)
-- LLM's independent ESI assessment and agreement flag
-- Clinical rationale from the LLM
-- Similar historical cases from Pinecone
-- Escalation flags
-
-`schemas.py` will need to be extended accordingly.
+The reconciled label is always the **more cautious** of model vs LLM:
+```python
+reconciled_class = min(model_class, llm_class)  # lower index = higher severity
+```
 
 ---
 
@@ -177,6 +189,7 @@ When orchestration is complete, the response will include additional fields sour
 |----------------------------------|---------------------------|-------------------|
 | `TRIAGE_SAGEMAKER_ENDPOINT_NAME` | `sagemaker_endpoint_name` | `"edtriage-live"` |
 | `TRIAGE_AWS_REGION`              | `aws_region`              | `"us-east-1"`     |
+| `TRIAGE_AWS_PROFILE`             | `aws_profile`             | `"ed-triage"`     |
 | `TRIAGE_USE_MOCK`                | `use_mock`                | `False`           |
 | `TRIAGE_DEFAULT_MODEL`           | `default_model`           | `"arch4"`         |
 
@@ -210,22 +223,22 @@ streamlit run frontend/app.py
 ## Task List
 
 ### Completed
+
 - [x] Create FastAPI backend (`main.py`, `schemas.py`, `config.py`, `sagemaker_service.py`)
 - [x] Build Streamlit frontend (`frontend/app.py`)
 - [x] Deploy `edtriage-live` SageMaker endpoint via `repack_and_deploy.py`
 - [x] Integrate backend with live endpoint (`use_mock=False` by default)
-- [x] Refactor `sagemaker_service.py`: extract `invoke_endpoint` as a reusable function, rename orchestration entry point to `run_triage_inference`
+- [x] Refactor `sagemaker_service.py`: extract `invoke_endpoint`, implement `run_triage_inference` as pipeline entry point
 - [x] Add `Makefile` with `deploy-endpoint` and `delete-endpoint` targets
-
-### Pending — LangGraph + RAG Integration
-- [ ] Create `orchestration/` service directory as a sibling to `backend/`
-- [ ] Move `invoke_endpoint` from `backend/sagemaker_service.py` into `orchestration/`
-- [ ] Implement the orchestration service using `src/agents/` (LangGraph) and `src/retreival/` (Pinecone RAG)
-- [ ] Update `run_triage_inference` in `backend/sagemaker_service.py` to delegate to `orchestration/`
-- [ ] Extend `TriageResponse` in `schemas.py` to surface enriched fields
-- [ ] Update `frontend/app.py` to display enriched fields (rationale, similar cases, flags)
-- [ ] Verify Pinecone index (`ed-triage-cases`) is populated and reachable
-- [ ] Verify Bedrock access (Claude + Titan embed) from the backend runtime environment
+- [x] Implement LangGraph agentic pipeline (`src/agents/graph.py`, `nodes.py`, `state.py`, `prompts.py`)
+- [x] Implement Pinecone RAG retrieval (`src/retreival/retrieval.py`) via Bedrock Titan embeddings
+- [x] Wire LangGraph pipeline into `run_triage_inference` — backend now calls graph instead of SageMaker directly
+- [x] Extend `TriageResponse` with enriched fields (reconciled label, llm_esi, clinical_rationale, similar_cases, flags, confidence_pct)
+- [x] Update frontend to display enriched results: clinical reasoning, key SHAP factors, similar cases with vitals/demographics, technical details card
+- [x] Add `sex` field to intake form and patient dict for LLM/RAG context
+- [x] Fix AWS auth: use `boto3.Session(profile_name=aws_profile)` with static IAM credentials (`ed-triage` profile)
+- [x] Verify Pinecone index (`ed-triage-cases`) populated and reachable
+- [x] Verify Bedrock access (Claude Sonnet + Titan embed) from backend runtime
 
 ---
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,4 +1,4 @@
-# Backend-only dependencies — install these locally
+# Backend + agentic pipeline dependencies — install these locally
 # Usage: pip install -r backend/requirements.txt
 
 fastapi>=0.115.0
@@ -8,3 +8,9 @@ boto3>=1.34.0
 python-dotenv>=1.0.0
 requests>=2.31.0
 streamlit>=1.32.0
+
+# Agentic pipeline (LangGraph + RAG + LLM)
+langgraph>=1.1.4
+langchain-core>=1.2.0
+langchain-aws>=0.2.0
+pinecone-client>=3.0.0

--- a/backend/sagemaker_service.py
+++ b/backend/sagemaker_service.py
@@ -135,7 +135,7 @@ def _request_to_patient(request: TriageRequest) -> dict[str, Any]:
     return {
         "chief_complaint": request.triage_notes,
         "age":             request.age,
-        "gender":          None,  # not collected in frontend schema
+        "gender":          request.sex,
         "heart_rate":      request.heart_rate,
         "systolic_bp":     request.sbp,
         "diastolic_bp":    request.dbp,

--- a/backend/sagemaker_service.py
+++ b/backend/sagemaker_service.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import copy
 import json
 import logging
+import uuid
 from typing import Any
 
 import boto3
@@ -129,19 +130,72 @@ def invoke_endpoint(payload: dict[str, Any]) -> dict[str, Any]:
     return json.loads(sm_result["Body"].read().decode("utf-8"))
 
 
+def _request_to_patient(request: TriageRequest) -> dict[str, Any]:
+    """Map TriageRequest fields to the patient dict shape the triage graph expects."""
+    return {
+        "chief_complaint": request.triage_notes,
+        "age":             request.age,
+        "gender":          None,  # not collected in frontend schema
+        "heart_rate":      request.heart_rate,
+        "systolic_bp":     request.sbp,
+        "diastolic_bp":    request.dbp,
+        "resp_rate":       request.resp_rate,
+        "temperature":     request.temp_f,
+        "spo2":            request.spo2,
+        "pain":            request.pain,
+        "arrival_transport": request.arrival_transport.upper(),
+        "hpi":             request.triage_notes,
+    }
+
+
 def run_triage_inference(request: TriageRequest) -> dict[str, Any]:
     """
     Inference orchestration entry point for the /predict route.
 
-    Transforms the frontend request, calls the SageMaker endpoint, and returns
-    a response dict ready for the frontend. Future: this will delegate to the
-    orchestration/ service instead of calling invoke_endpoint directly.
+    1. Calls the SageMaker endpoint to get the ML prediction.
+    2. Passes prediction + patient data through the LangGraph agentic pipeline
+       (RAG retrieval + LLM clinical analysis + synthesis).
+    3. Returns the enriched final_report shaped for TriageResponse.
     """
+    from src.agents.graph import triage_graph  # imported here to avoid circular import at module load
+
     model_used = request.model or settings.default_model
     sm_payload = transform_request(request)
 
     logger.info("Request payload (SageMaker format): %s", json.dumps(sm_payload, indent=2))
     raw_response = invoke_endpoint(sm_payload)
-    result = transform_response(raw_response, model_used)
-    logger.info("Response payload (frontend format): %s", json.dumps(result, indent=2))
+    logger.info("SageMaker raw response: %s", json.dumps(raw_response, indent=2))
+
+    patient = _request_to_patient(request)
+    thread_id = str(uuid.uuid4())
+
+    graph_result = triage_graph.invoke(
+        {"patient": patient, "prediction": raw_response},
+        config={"configurable": {"thread_id": thread_id}},
+    )
+    report = graph_result["final_report"]
+
+    # Shape final_report into the TriageResponse contract
+    probs = report.get("probabilities", {})
+    result = {
+        "predicted_class": report["triage_class"],
+        "predicted_label": report["triage_level"],
+        "probabilities":   probs,
+        "top_features":    report.get("shap_features") or [],
+        "safety_flag":     report.get("safety_flag") or False,
+        "safety_reason":   report.get("safety_reason"),
+        "model_used":      model_used,
+        # Enriched fields from the agentic pipeline
+        "reconciled_label":   report.get("reconciled_level"),
+        "reconciled_class":   report.get("reconciled_class"),
+        "llm_esi":            report.get("llm_esi"),
+        "llm_agreement":      report.get("llm_agreement"),
+        "clinical_rationale": report.get("clinical_rationale"),
+        "similar_cases":      report.get("similar_cases") or [],
+        "flags":              report.get("flags") or [],
+        "confidence_pct":     report.get("confidence_pct"),
+        "uncertainty_flag":   report.get("uncertainty_flag", False),
+    }
+
+    logger.info("Enriched response: %s", json.dumps(result, indent=2, default=str))
     return result

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -52,3 +52,14 @@ class TriageResponse(BaseModel):
         default=None, description="Human-readable explanation if flagged"
     )
     model_used: str = Field(description="Which model produced this result")
+
+    # Enriched fields from the agentic pipeline (LangGraph + RAG + LLM)
+    reconciled_label: Optional[str] = Field(default=None, description="More cautious of model vs LLM recommendation")
+    reconciled_class: Optional[int] = Field(default=None, description="0-based class index for reconciled_label")
+    llm_esi: Optional[int] = Field(default=None, description="LLM independent ESI recommendation (1/2/3)")
+    llm_agreement: Optional[bool] = Field(default=None, description="True if LLM agrees with model prediction")
+    clinical_rationale: Optional[str] = Field(default=None, description="LLM clinical reasoning narrative")
+    similar_cases: Optional[list] = Field(default=None, description="Top RAG-retrieved historical cases")
+    flags: Optional[list[str]] = Field(default=None, description="Escalation signals and uncertainty notes")
+    confidence_pct: Optional[int] = Field(default=None, description="Model confidence 0-100")
+    uncertainty_flag: Optional[bool] = Field(default=None, description="True if confidence is below threshold")

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -17,6 +17,7 @@ class TriageRequest(BaseModel):
     model: str = Field(default="arch4", description="Model architecture to invoke")
     triage_notes: str = Field(..., description="Free-text clinical notes from the UI")
     age: Optional[int] = Field(default=None, description="Patient age in years")
+    sex: Optional[str] = Field(default=None, description="Patient sex: Female, Male, or Other")
     heart_rate: Optional[int] = Field(default=None, description="BPM")
     resp_rate: Optional[int] = Field(default=None, description="Breaths per minute")
     sbp: Optional[int] = Field(default=None, description="Systolic blood pressure (mmHg)")

--- a/frontend/app.py
+++ b/frontend/app.py
@@ -394,26 +394,36 @@ def inject_css():
 
     /* ── Input field overrides ─────────────────────────────────── */
     [data-testid="stNumberInput"] input,
-    [data-testid="stTextArea"] textarea,
-    [data-testid="stSelectbox"] [data-baseweb="select"] {
-        background: var(--surface-container-lowest) !important;
-        border: none !important;
+    [data-testid="stTextInput"] input,
+    [data-testid="stTextArea"] textarea {
+        background: #f8fafc !important;
+        border: 1px solid #dde3ed !important;
         border-radius: 8px !important;
-        font-weight: 700 !important;
+        font-weight: 500 !important;
+        font-size: 14px !important;
         color: var(--on-surface) !important;
         font-family: 'Inter', sans-serif !important;
+        padding: 10px 14px !important;
+    }
+    [data-testid="stNumberInput"] input:focus,
+    [data-testid="stTextInput"] input:focus,
+    [data-testid="stTextArea"] textarea:focus {
+        border-color: var(--primary) !important;
+        box-shadow: 0 0 0 3px rgba(0,71,141,0.08) !important;
+        background: #fff !important;
     }
     [data-testid="stTextArea"] textarea {
-        background: var(--surface-container-low) !important;
+        font-size: 14px !important;
         font-weight: 400 !important;
-        font-size: 16px !important;
         line-height: 1.7 !important;
+        resize: none !important;
     }
-    [data-testid="stTextArea"] textarea:focus {
-        box-shadow: 0 0 0 2px var(--primary-fixed) !important;
-    }
-    [data-testid="stNumberInput"] input:focus {
-        box-shadow: 0 0 0 2px var(--primary-fixed) !important;
+    [data-testid="stSelectbox"] [data-baseweb="select"] > div {
+        background: #f8fafc !important;
+        border: 1px solid #dde3ed !important;
+        border-radius: 8px !important;
+        font-size: 14px !important;
+        color: var(--on-surface) !important;
     }
 
     /* hide default streamlit labels — we use custom HTML labels */
@@ -431,6 +441,30 @@ def inject_css():
     [data-testid="stSlider"] [data-testid="stTickBarMin"],
     [data-testid="stSlider"] [data-testid="stTickBarMax"] {
         display: none !important;
+    }
+
+    /* ── Intake form card ──────────────────────────────────────── */
+    .intake-card {
+        background: #ffffff;
+        border-radius: 16px;
+        border: 1px solid #e2e8f0;
+        box-shadow: 0 1px 4px rgba(0,0,0,0.06);
+        padding: 32px 36px;
+        margin-bottom: 24px;
+    }
+    .intake-section-title {
+        font-size: 11px; font-weight: 700;
+        text-transform: uppercase; letter-spacing: 1.5px;
+        color: var(--on-surface-variant);
+        margin-bottom: 16px; margin-top: 24px;
+        padding-bottom: 8px;
+        border-bottom: 1px solid #f1f5f9;
+    }
+    .intake-section-title:first-child { margin-top: 0; }
+    .field-label {
+        font-size: 12px; font-weight: 600;
+        color: #475569; margin-bottom: 4px;
+        letter-spacing: 0.2px;
     }
 
     /* ── Results page styles ───────────────────────────────────── */
@@ -729,12 +763,11 @@ def inject_css():
         margin-right: 6px;
     }
 
-    /* ── Streamlit number input hide steppers for cleaner look ── */
-    [data-testid="stNumberInput"] button {
-        display: none !important;
-    }
+    /* Hide number input steppers */
+    [data-testid="stNumberInput"] button { display: none !important; }
+    [data-testid="stNumberInput"] > div { gap: 0 !important; }
 
-    /* Make text area label hidden since we use custom */
+    /* Hide text area label */
     [data-testid="stTextArea"] label { display: none !important; }
 
     /* ── Force sidebar to always be visible ────────────────────── */
@@ -850,7 +883,6 @@ def render_sidebar():
 # ── Page 1: Intake form ──────────────────────────────────────────────────────
 
 def render_intake_page():
-    # Top header bar
     st.markdown("""
     <div class="top-header">
         <div class="top-header-left">
@@ -859,7 +891,6 @@ def render_intake_page():
             <span class="page-title">New Patient Entry</span>
         </div>
         <div class="top-header-right">
-            <span class="search-box">&#128269; &nbsp;Search Patients...</span>
             <span class="header-icon">&#128276;</span>
             <span class="header-icon">&#9881;</span>
             <div class="avatar">&#128100;</div>
@@ -867,157 +898,71 @@ def render_intake_page():
     </div>
     """, unsafe_allow_html=True)
 
-    # Two-column layout
-    left_col, right_col = st.columns([3, 2], gap="large")
+    # ── Patient Info ─────────────────────────────────────────────
+    st.markdown('<div class="intake-section-title">Patient Information</div>', unsafe_allow_html=True)
+    c1, c2, c3 = st.columns([2, 2, 1])
+    with c1:
+        st.markdown('<div class="field-label">First Name</div>', unsafe_allow_html=True)
+        st.text_input("First Name", key="first_name", placeholder="Jane", label_visibility="collapsed")
+    with c2:
+        st.markdown('<div class="field-label">Last Name</div>', unsafe_allow_html=True)
+        st.text_input("Last Name", key="last_name", placeholder="Smith", label_visibility="collapsed")
+    with c3:
+        st.markdown('<div class="field-label">Age</div>', unsafe_allow_html=True)
+        st.number_input("Age", min_value=0, max_value=120, value=None, key="age",
+                        placeholder="—", label_visibility="collapsed")
 
-    with left_col:
-        # Primary Documentation card
-        st.markdown("""
-        <div class="card" style="min-height: 580px; display: flex; flex-direction: column;">
-            <div style="display: flex; justify-content: space-between; align-items: flex-end; margin-bottom: 20px;">
-                <div>
-                    <div class="section-label primary">Primary Documentation</div>
-                    <div class="section-title" style="margin-bottom: 0;">Triage Notes</div>
-                </div>
-                <div class="badge-row">
-                    <span class="badge">Voice Enabled</span>
-                    <span class="badge">Autosave Active</span>
-                </div>
-            </div>
-        </div>
-        """, unsafe_allow_html=True)
+    # ── Triage Notes ─────────────────────────────────────────────
+    st.markdown('<div class="intake-section-title">Triage Notes</div>', unsafe_allow_html=True)
+    st.text_area(
+        "Triage Notes", height=160, key="triage_notes",
+        placeholder="Chief complaint, symptoms, relevant history...",
+        label_visibility="collapsed",
+    )
 
-        # Overlay the text area on top of the card using negative margin
-        st.markdown("<div style='margin-top:-520px; padding: 0 32px 32px;'>",
-                    unsafe_allow_html=True)
-        st.text_area(
-            "Triage Notes",
-            height=450,
-            key="triage_notes",
-            placeholder="Enter chief complaint, detailed symptoms, and medical history here...",
-            label_visibility="collapsed",
-        )
-        st.markdown("</div>", unsafe_allow_html=True)
+    # ── Vitals ───────────────────────────────────────────────────
+    st.markdown('<div class="intake-section-title">Vitals</div>', unsafe_allow_html=True)
+    v1, v2, v3, v4, v5, v6 = st.columns(6)
+    with v1:
+        st.markdown('<div class="field-label">Heart Rate</div>', unsafe_allow_html=True)
+        st.number_input("HR", min_value=20, max_value=250, value=None, key="heart_rate",
+                        placeholder="BPM", label_visibility="collapsed")
+    with v2:
+        st.markdown('<div class="field-label">Resp Rate</div>', unsafe_allow_html=True)
+        st.number_input("RR", min_value=4, max_value=60, value=None, key="resp_rate",
+                        placeholder="br/m", label_visibility="collapsed")
+    with v3:
+        st.markdown('<div class="field-label">SBP</div>', unsafe_allow_html=True)
+        st.number_input("SBP", min_value=40, max_value=300, value=None, key="sbp",
+                        placeholder="mmHg", label_visibility="collapsed")
+    with v4:
+        st.markdown('<div class="field-label">DBP</div>', unsafe_allow_html=True)
+        st.number_input("DBP", min_value=10, max_value=200, value=None, key="dbp",
+                        placeholder="mmHg", label_visibility="collapsed")
+    with v5:
+        st.markdown('<div class="field-label">SpO2</div>', unsafe_allow_html=True)
+        st.number_input("SpO2", min_value=50, max_value=100, value=None, key="spo2",
+                        placeholder="%", label_visibility="collapsed")
+    with v6:
+        st.markdown('<div class="field-label">Temp (°F)</div>', unsafe_allow_html=True)
+        st.number_input("Temp", min_value=85.0, max_value=115.0, value=None, key="temp_f",
+                        placeholder="°F", step=0.1, label_visibility="collapsed")
 
-    with right_col:
-        # Vitals panel
-        st.markdown("""
-        <div class="section-label secondary">Diagnostic Layer</div>
-        <div class="section-title">Optional Vitals</div>
-        """, unsafe_allow_html=True)
-
-        # First Name | Last Name
-        n1, n2 = st.columns(2)
-        with n1:
-            st.markdown('<div class="vital-label">First Name</div>', unsafe_allow_html=True)
-            st.text_input("First Name", key="first_name", placeholder="Jane",
-                          label_visibility="collapsed")
-        with n2:
-            st.markdown('<div class="vital-label">Last Name</div>', unsafe_allow_html=True)
-            st.text_input("Last Name", key="last_name", placeholder="Smith",
-                          label_visibility="collapsed")
-
-        # Age — full width
-        st.markdown('<div class="vital-label">Age</div>', unsafe_allow_html=True)
-        st.number_input("Age", min_value=0, max_value=120, value=None,
-                        key="age", placeholder="Years", label_visibility="collapsed")
-
-        # Heart Rate | RR
-        v1, v2 = st.columns(2)
-        with v1:
-            st.markdown('<div class="vital-label">Heart Rate (BPM)</div>',
-                        unsafe_allow_html=True)
-            st.number_input("Heart Rate", min_value=20, max_value=250,
-                            value=None, key="heart_rate", placeholder="72",
-                            label_visibility="collapsed")
-        with v2:
-            st.markdown('<div class="vital-label">RR (Breaths/m)</div>',
-                        unsafe_allow_html=True)
-            st.number_input("RR", min_value=4, max_value=60, value=None,
-                            key="resp_rate", placeholder="16",
-                            label_visibility="collapsed")
-
-        # SBP | DBP
-        v3, v4 = st.columns(2)
-        with v3:
-            st.markdown('<div class="vital-label">SBP (mmHg)</div>',
-                        unsafe_allow_html=True)
-            st.number_input("SBP", min_value=40, max_value=300, value=None,
-                            key="sbp", placeholder="120",
-                            label_visibility="collapsed")
-        with v4:
-            st.markdown('<div class="vital-label">DBP (mmHg)</div>',
-                        unsafe_allow_html=True)
-            st.number_input("DBP", min_value=10, max_value=200, value=None,
-                            key="dbp", placeholder="80",
-                            label_visibility="collapsed")
-
-        # SpO2 | Temp
-        v5, v6 = st.columns(2)
-        with v5:
-            st.markdown('<div class="vital-label">SpO2 (%)</div>',
-                        unsafe_allow_html=True)
-            st.number_input("SpO2", min_value=50, max_value=100, value=None,
-                            key="spo2", placeholder="98",
-                            label_visibility="collapsed")
-        with v6:
-            st.markdown('<div class="vital-label">Temp (F)</div>',
-                        unsafe_allow_html=True)
-            st.number_input("Temp", min_value=85.0, max_value=115.0,
-                            value=None, key="temp_f", placeholder="98.6",
-                            step=0.1, label_visibility="collapsed")
-
-        # Pain slider
+    # ── Pain + Transport ─────────────────────────────────────────
+    st.markdown('<div class="intake-section-title">Assessment</div>', unsafe_allow_html=True)
+    p_col, t_col = st.columns([3, 1])
+    with p_col:
         pain_val = st.session_state.get("pain", 4)
-        st.markdown(f"""
-        <div class="pain-header">
-            <span class="pain-label">Pain Level (0-10)</span>
-            <span class="pain-value">{pain_val} / 10</span>
-        </div>
-        """, unsafe_allow_html=True)
-        st.slider("Pain", min_value=0, max_value=10, value=4,
-                  key="pain", label_visibility="collapsed")
-        st.markdown("""
-        <div class="pain-range">
-            <span>None</span>
-            <span>Severe</span>
-        </div>
-        """, unsafe_allow_html=True)
+        st.markdown(f'<div class="field-label">Pain Level &nbsp;<span style="color:var(--primary);font-weight:700;">{pain_val} / 10</span></div>', unsafe_allow_html=True)
+        st.slider("Pain", min_value=0, max_value=10, value=4, key="pain", label_visibility="collapsed")
+    with t_col:
+        st.markdown('<div class="field-label">Arrival Transport</div>', unsafe_allow_html=True)
+        st.selectbox("Transport", TRANSPORT_OPTIONS, key="arrival_transport", label_visibility="collapsed")
 
-        # Arrival transport
-        st.markdown('<div class="vital-label" style="margin-top:12px;">Arrival Transport</div>',
-                    unsafe_allow_html=True)
-        st.selectbox("Transport", TRANSPORT_OPTIONS, key="arrival_transport",
-                     label_visibility="collapsed")
-
-        # System monitoring indicator
-        st.markdown("""
-        <div class="monitor-card">
-            <div class="pulse-ring">
-                <span class="pulse-icon">&#9764;</span>
-            </div>
-            <div>
-                <div class="monitor-label">System Monitoring</div>
-                <div class="monitor-status">Ready for diagnostic stream</div>
-            </div>
-        </div>
-        """, unsafe_allow_html=True)
-
-        # Tip card
-        st.markdown("""
-        <div class="tip-card">
-            <div class="tip-icon-box">&#128161;</div>
-            <div>
-                <div class="tip-title">Did you know?</div>
-                <div class="tip-text">Type 'HX' to quickly import patient's known clinical history.</div>
-            </div>
-        </div>
-        """, unsafe_allow_html=True)
-
-    # Submit button — centered
-    _l, center, _r = st.columns([1, 2, 1])
+    # Submit button
+    _l, center, _r = st.columns([2, 3, 2])
     with center:
-        if st.button("&#10004;  Complete Triage Assessment", type="primary",
+        if st.button("Run Triage Assessment", type="primary",
                      use_container_width=True, key="submit_btn"):
             form_data = {
                 "first_name": st.session_state.get("first_name", ""),

--- a/frontend/app.py
+++ b/frontend/app.py
@@ -1097,249 +1097,200 @@ def render_results_page():
             st.rerun()
         return
 
-    prob = triage_result.get("probabilities", {
-        "L1-Critical": 0.0, "L2-Emergent": 0.0, "L3-Urgent/LessUrgent": 0.0
-    })
     predicted_label = triage_result.get("predicted_label", "Unknown")
-    model_used = triage_result.get("model_used", "arch4")
-    safety_flag = triage_result.get("safety_flag", False)
-    safety_reason = triage_result.get("safety_reason", None)
-    top_features = triage_result.get("top_features", [])
+    model_used      = triage_result.get("model_used", "arch4")
+    safety_flag     = triage_result.get("safety_flag", False)
+    safety_reason   = triage_result.get("safety_reason", None)
+    top_features    = triage_result.get("top_features", [])
 
-    # Agentic pipeline enriched fields
-    reconciled_label = triage_result.get("reconciled_label")
-    llm_agreement = triage_result.get("llm_agreement")
-    llm_esi = triage_result.get("llm_esi")
+    reconciled_label   = triage_result.get("reconciled_label") or predicted_label
+    llm_agreement      = triage_result.get("llm_agreement")
     clinical_rationale = triage_result.get("clinical_rationale")
-    similar_cases = triage_result.get("similar_cases") or []
-    flags = triage_result.get("flags") or []
+    similar_cases      = triage_result.get("similar_cases") or []
+    was_upgraded       = llm_agreement is False and reconciled_label != predicted_label
 
-    # Derive UI data from real backend response
-    drivers = shap_features_to_drivers(top_features)
+    # Nurse-friendly label/colour mapping
+    LEVEL_META = {
+        "L1-Critical": {
+            "color": "#b91c1c", "bg": "#fef2f2", "border": "#fca5a5",
+            "badge_bg": "#fee2e2", "badge_color": "#991b1b",
+            "title": "ESI 1 — Immediate / Critical",
+            "action": "Bring to resuscitation bay immediately. Do not leave unattended.",
+            "icon": "🚨",
+        },
+        "L2-Emergent": {
+            "color": "#c2410c", "bg": "#fff7ed", "border": "#fdba74",
+            "badge_bg": "#ffedd5", "badge_color": "#9a3412",
+            "title": "ESI 2 — Emergent",
+            "action": "Assign to monitored bed within 15 minutes. Notify attending.",
+            "icon": "⚠️",
+        },
+        "L3-Urgent": {
+            "color": "#a16207", "bg": "#fefce8", "border": "#fde047",
+            "badge_bg": "#fef9c3", "badge_color": "#854d0e",
+            "title": "ESI 3 — Urgent / Less Urgent",
+            "action": "Place in waiting area. Reassess vitals every 30 minutes.",
+            "icon": "🔔",
+        },
+    }
+    # Normalise key
+    rec_key = reconciled_label.replace("/LessUrgent", "").replace("LessUrgent", "").strip()
+    meta = LEVEL_META.get(rec_key, LEVEL_META["L3-Urgent"])
 
-    # Parse label
-    label_parts = predicted_label.split("-", 1)
-    level_code = label_parts[0] if label_parts else predicted_label
-    level_desc = label_parts[1].upper() if len(label_parts) > 1 else ""
-
-    # ── Collapsed patient header ──────────────────────────────────
-    first_name = form_data.get("first_name", "").strip()
-    last_name  = form_data.get("last_name", "").strip()
+    # ── Patient header + new patient button ──────────────────────
+    first_name   = form_data.get("first_name", "").strip()
+    last_name    = form_data.get("last_name", "").strip()
     patient_name = f"{first_name} {last_name}".strip() or "Patient"
-    age_val = form_data.get("age")
+    age_val      = form_data.get("age")
     notes_preview = form_data.get("triage_notes", "")[:120]
-    age_str = f", {age_val}y" if age_val else ""
-    st.markdown(f"""
-    <div style="background:#f8fafc;border:1px solid #dde3ed;border-radius:12px;
-                padding:16px 20px;margin-bottom:20px;
-                display:flex;align-items:center;gap:16px;">
-        <div style="font-size:28px;">&#128100;</div>
-        <div style="flex:1;">
-            <div style="font-size:14px;font-weight:700;color:#0f172a;">{patient_name}{age_str}</div>
-            <div style="font-size:12px;color:#64748b;margin-top:2px;">{notes_preview}{"..." if len(form_data.get("triage_notes","")) > 120 else ""}</div>
+    age_str      = f", {age_val}y" if age_val else ""
+
+    hdr_col, btn_col = st.columns([10, 2])
+    with hdr_col:
+        st.markdown(f"""
+        <div style="background:#f8fafc;border:1px solid #dde3ed;border-radius:12px;
+                    padding:14px 20px;display:flex;align-items:center;gap:16px;">
+            <div style="font-size:26px;">&#128100;</div>
+            <div style="flex:1;">
+                <div style="font-size:14px;font-weight:700;color:#0f172a;">{patient_name}{age_str}</div>
+                <div style="font-size:12px;color:#64748b;margin-top:2px;">{notes_preview}{"..." if len(form_data.get("triage_notes","")) > 120 else ""}</div>
+            </div>
+            <div style="font-size:11px;color:#94a3b8;">{datetime.now(timezone.utc).strftime("%H:%M UTC")}</div>
         </div>
-        <div style="font-size:11px;color:#94a3b8;">{datetime.now(timezone.utc).strftime("%H:%M UTC")}</div>
+        """, unsafe_allow_html=True)
+    with btn_col:
+        if st.button("Triage Next Patient", type="primary", use_container_width=True, key="new_patient_btn"):
+            for key in ["triage_notes", "age", "heart_rate", "resp_rate",
+                        "sbp", "dbp", "spo2", "temp_f", "pain",
+                        "arrival_transport", "form_data", "triage_result", "is_loading"]:
+                if key in st.session_state:
+                    del st.session_state[key]
+            st.session_state.page = "intake"
+            st.rerun()
+
+    # ── Triage decision card ──────────────────────────────────────
+    st.markdown(f"""
+    <div style="background:{meta['bg']};border:1px solid {meta['border']};
+                border-left:6px solid {meta['color']};border-radius:12px;
+                padding:24px 28px;margin:16px 0;">
+        <div style="display:flex;align-items:flex-start;gap:16px;">
+            <div style="font-size:36px;line-height:1;">{meta['icon']}</div>
+            <div style="flex:1;">
+                <div style="font-size:11px;font-weight:700;text-transform:uppercase;
+                            letter-spacing:1.5px;color:{meta['color']};margin-bottom:4px;">
+                    Triage Priority
+                </div>
+                <div style="font-size:28px;font-weight:900;color:{meta['color']};
+                            letter-spacing:-0.5px;line-height:1.1;margin-bottom:8px;">
+                    {meta['title']}
+                </div>
+                <div style="font-size:14px;font-weight:600;color:{meta['color']};">
+                    {meta['action']}
+                </div>
+            </div>
+        </div>
     </div>
     """, unsafe_allow_html=True)
 
-    # Safety flag banner
+    if was_upgraded:
+        st.markdown(f"""
+        <div style="margin-bottom:12px;font-size:13px;color:{meta['color']};
+                    background:{meta['badge_bg']};border-radius:8px;padding:10px 14px;">
+            ↑ <strong>Upgraded from initial assessment</strong> — clinical review flagged higher urgency
+        </div>
+        """, unsafe_allow_html=True)
+
     if safety_flag and safety_reason:
-        st.warning(f"\u26a0\ufe0f **Safety Alert:** {safety_reason}")
-
-    # Reconciled label banner
-    if llm_agreement is False and reconciled_label and reconciled_label != predicted_label:
-        esi_num = llm_esi or "?"
         st.markdown(f"""
-        <div class="reconciled-banner">
-            <div class="reconciled-icon">&#9888;</div>
-            <div>
-                <div class="reconciled-title">LLM CLINICAL OVERRIDE — Effective Recommendation: {reconciled_label}</div>
-                <div class="reconciled-body">
-                    The model predicted <strong>{predicted_label}</strong>, but independent LLM reasoning
-                    recommended ESI {esi_num} (<strong>{reconciled_label}</strong>).
-                    The more cautious level is used for protocol selection.
-                </div>
-            </div>
+        <div style="margin-bottom:12px;font-size:13px;color:#7c2d12;
+                    background:#fff7ed;border:1px solid #fdba74;border-radius:8px;padding:10px 14px;">
+            ⚠️ <strong>Safety Alert:</strong> {safety_reason}
         </div>
         """, unsafe_allow_html=True)
 
-    # Escalation flags
-    if flags:
-        flag_items = "".join(
-            f'<div class="flag-item"><span class="flag-icon">&#9873;</span>{f}</div>'
-            for f in flags
-        )
-        st.markdown(f'<div class="flags-section">{flag_items}</div>', unsafe_allow_html=True)
-
-    # ── Priority card (smaller, full width) ───────────────────────
-    st.markdown(f"""
-    <div style="background:#fff;border-radius:12px;border-left:5px solid var(--tertiary);
-                box-shadow:0 1px 3px rgba(0,0,0,0.06);
-                display:flex;align-items:center;gap:0;margin-bottom:20px;overflow:hidden;">
-        <div style="padding:20px 28px;flex:1;">
-            <div style="font-family:'Public Sans',sans-serif;font-size:10px;font-weight:700;
-                        color:var(--tertiary);background:var(--tertiary-fixed);
-                        padding:3px 8px;border-radius:4px;display:inline-block;margin-bottom:10px;">
-                PREDICTED PRIORITY
-            </div>
-            <div style="font-size:36px;font-weight:900;color:var(--tertiary);
-                        letter-spacing:-1px;line-height:1;margin-bottom:6px;">
-                {level_code} — {level_desc}
-            </div>
-            <div style="font-size:13px;color:var(--on-surface-variant);">
-                Model: <strong>{model_used}</strong> &nbsp;·&nbsp; Classified as <strong>{predicted_label}</strong>
-            </div>
-        </div>
-        <div style="background:var(--tertiary-container);color:#ffceca;
-                    padding:20px 32px;text-align:center;min-width:160px;align-self:stretch;
-                    display:flex;flex-direction:column;justify-content:center;">
-            <div style="font-size:32px;margin-bottom:4px;">&#9888;</div>
-            <div style="font-family:'Public Sans',sans-serif;font-size:9px;font-weight:700;
-                        text-transform:uppercase;letter-spacing:2px;opacity:0.8;margin-bottom:2px;">
-                Predicted Class
-            </div>
-            <div style="font-size:16px;font-weight:700;">{predicted_label}</div>
-        </div>
-    </div>
-    """, unsafe_allow_html=True)
-
-    # ── Confidence + Drivers ──────────────────────────────────────
-    c_left, c_right = st.columns(2)
-
-    with c_left:
-        l1_pct = prob.get("L1-Critical", 0.0) * 100
-        l2_pct = prob.get("L2-Emergent", 0.0) * 100
-        l3_pct = prob.get("L3-Urgent/LessUrgent", 0.0) * 100
-        st.markdown(f"""
-        <div class="confidence-section">
-            <div class="confidence-title">Confidence Breakdown</div>
-            <div class="conf-row">
-                <div class="conf-labels">
-                    <span class="conf-name critical">Level 1 (Critical)</span>
-                    <span class="conf-pct">{l1_pct:.1f}%</span>
-                </div>
-                <div class="conf-track lg">
-                    <div class="conf-fill critical" style="width:{l1_pct}%"></div>
-                </div>
-            </div>
-            <div class="conf-row">
-                <div class="conf-labels">
-                    <span class="conf-name muted">Level 2 (Emergent)</span>
-                    <span class="conf-pct muted">{l2_pct:.1f}%</span>
-                </div>
-                <div class="conf-track sm">
-                    <div class="conf-fill muted" style="width:{l2_pct}%"></div>
-                </div>
-            </div>
-            <div class="conf-row">
-                <div class="conf-labels">
-                    <span class="conf-name muted">Level 3 (Urgent)</span>
-                    <span class="conf-pct muted">{l3_pct:.1f}%</span>
-                </div>
-                <div class="conf-track sm">
-                    <div class="conf-fill faint" style="width:max(1%,{l3_pct}%)"></div>
-                </div>
-            </div>
-        </div>
-        """, unsafe_allow_html=True)
-
-    with c_right:
-        drivers_items = []
-        for d in drivers:
-            bg_cls = "critical-bg" if d["critical"] else "normal-bg"
-            icon_cls = "critical" if d["critical"] else "primary"
-            title_cls = "critical" if d["critical"] else "normal"
-            drivers_items.append(
-                f'<div class="driver-item {bg_cls}">'
-                f'<span class="driver-icon {icon_cls}">{d["icon"]}</span>'
-                f'<div>'
-                f'<div class="driver-title {title_cls}">{d["title"]}</div>'
-                f'<div class="driver-detail">{d["detail"]}</div>'
-                f'</div></div>'
-            )
-        drivers_html = "".join(drivers_items) if drivers_items else (
-            "<p style='color:var(--on-surface-variant);font-size:13px;'>No SHAP feature data available.</p>"
-        )
-        st.markdown(
-            f'<div class="drivers-section">'
-            f'<div class="confidence-title">Clinical Drivers</div>'
-            f'{drivers_html}'
-            f'</div>',
-            unsafe_allow_html=True,
-        )
-
-    # ── Action button ─────────────────────────────────────────────
-    if st.button("Triage Another Patient", use_container_width=True, key="restart_btn"):
-        for key in ["triage_notes", "age", "heart_rate", "resp_rate",
-                    "sbp", "dbp", "spo2", "temp_f", "pain",
-                    "arrival_transport", "form_data", "triage_result", "is_loading"]:
-            if key in st.session_state:
-                del st.session_state[key]
-        st.session_state.page = "intake"
-        st.rerun()
-
-    # Clinical Rationale
+    # ── Clinical reasoning ────────────────────────────────────────
     if clinical_rationale:
-        st.markdown("""
+        st.markdown(f"""
         <div class="rationale-section">
-            <div class="confidence-title">Clinical Rationale (LLM Analysis)</div>
+            <div class="confidence-title">Clinical Reasoning</div>
+            <div class="rationale-text">{clinical_rationale}</div>
+        </div>
         """, unsafe_allow_html=True)
-        st.markdown(f'<div class="rationale-text">{clinical_rationale}</div>', unsafe_allow_html=True)
-        st.markdown("</div>", unsafe_allow_html=True)
 
-    # Similar Historical Cases
+    # ── Key vitals that drove the decision (from SHAP, plain English) ──
+    if top_features:
+        vital_rows = ""
+        for f in top_features:
+            name = FEATURE_DISPLAY_NAMES.get(f.get("feature", ""), f.get("feature", "").replace("_", " ").title())
+            direction = f.get("direction", "")
+            shap = f.get("shap", 0)
+            is_against = "away" in direction
+            tag_color  = "#b91c1c" if is_against else "#15803d"
+            tag_bg     = "#fee2e2" if is_against else "#dcfce7"
+            tag_text   = "Working against this level" if is_against else "Supporting this level"
+            vital_rows += f"""
+            <tr>
+                <td style="font-weight:600;color:#0f172a;">{name}</td>
+                <td><span style="background:{tag_bg};color:{tag_color};font-size:11px;
+                                 font-weight:600;padding:2px 8px;border-radius:4px;">
+                    {tag_text}
+                </span></td>
+            </tr>"""
+        st.markdown(f"""
+        <div class="rationale-section" style="margin-top:16px;">
+            <div class="confidence-title">Key Factors</div>
+            <table style="width:100%;border-collapse:collapse;font-size:13px;">
+                <tbody>{vital_rows}</tbody>
+            </table>
+        </div>
+        """, unsafe_allow_html=True)
+
+    # ── Similar past cases ────────────────────────────────────────
     if similar_cases:
+        URGENCY_LABEL = {1: "Critical", 2: "Emergent", 3: "Urgent"}
+        URGENCY_COLOR = {1: "#b91c1c", 2: "#c2410c", 3: "#a16207"}
+        URGENCY_BG    = {1: "#fee2e2", 2: "#ffedd5", 3: "#fef9c3"}
         rows = ""
         for c in similar_cases:
-            esi = c.get("triage_level", "?")
-            esi_cls = f"esi-{esi}" if esi in (1, 2, 3) else "esi-3"
-            hr = f"{c['heart_rate']:.0f}" if c.get("heart_rate") else "—"
-            sbp = c.get("sbp"); dbp = c.get("dbp")
-            bp = f"{sbp:.0f}/{dbp:.0f}" if sbp and dbp else "—"
-            spo2 = f"{c['spo2']:.0f}%" if c.get("spo2") else "—"
+            esi = c.get("triage_level")
+            urgency_label = URGENCY_LABEL.get(esi, "Unknown")
+            urg_color = URGENCY_COLOR.get(esi, "#64748b")
+            urg_bg    = URGENCY_BG.get(esi, "#f1f5f9")
+            outcome   = (c.get("outcome") or "—").title()
+            complaint = (c.get("chief_complaint") or "—").title()
+            diagnosis = (c.get("diagnosis") or "—").title()
             rows += f"""
-            <tr>
-                <td><span class="sim-score">{c.get('similarity', 0):.2f}</span></td>
-                <td><span class="esi-badge {esi_cls}">ESI {esi}</span></td>
-                <td>{c.get('chief_complaint') or '—'}</td>
-                <td>{hr}</td>
-                <td>{bp}</td>
-                <td>{spo2}</td>
-                <td>{c.get('diagnosis') or '—'}</td>
-                <td>{c.get('outcome') or '—'}</td>
+            <tr style="border-bottom:1px solid #f1f5f9;">
+                <td style="padding:10px;font-weight:600;color:#0f172a;">{complaint}</td>
+                <td style="padding:10px;color:#475569;">{diagnosis}</td>
+                <td style="padding:10px;">
+                    <span style="background:{urg_bg};color:{urg_color};font-size:11px;
+                                 font-weight:700;padding:2px 8px;border-radius:4px;">
+                        ESI {esi} — {urgency_label}
+                    </span>
+                </td>
+                <td style="padding:10px;color:#475569;">{outcome}</td>
             </tr>"""
         st.markdown(f"""
         <div class="cases-section">
-            <div class="confidence-title">Similar Historical Cases (RAG)</div>
-            <table class="cases-table">
+            <div class="confidence-title">Similar Past Cases</div>
+            <table style="width:100%;border-collapse:collapse;font-size:13px;">
                 <thead>
-                    <tr>
-                        <th>Similarity</th>
-                        <th>ESI</th>
-                        <th>Chief Complaint</th>
-                        <th>HR</th>
-                        <th>BP</th>
-                        <th>SpO2</th>
-                        <th>Diagnosis</th>
-                        <th>Outcome</th>
+                    <tr style="border-bottom:2px solid #e2e8f0;">
+                        <th style="text-align:left;padding:8px 10px;font-size:10px;font-weight:700;
+                                   text-transform:uppercase;letter-spacing:1px;color:#64748b;">Chief Complaint</th>
+                        <th style="text-align:left;padding:8px 10px;font-size:10px;font-weight:700;
+                                   text-transform:uppercase;letter-spacing:1px;color:#64748b;">Diagnosis</th>
+                        <th style="text-align:left;padding:8px 10px;font-size:10px;font-weight:700;
+                                   text-transform:uppercase;letter-spacing:1px;color:#64748b;">ESI Level</th>
+                        <th style="text-align:left;padding:8px 10px;font-size:10px;font-weight:700;
+                                   text-transform:uppercase;letter-spacing:1px;color:#64748b;">Outcome</th>
                     </tr>
                 </thead>
                 <tbody>{rows}</tbody>
             </table>
         </div>
         """, unsafe_allow_html=True)
-
-    # Footer — show actual model_used from backend response
-    now_utc = datetime.now(timezone.utc).strftime("%H:%M:%S UTC")
-    st.markdown(f"""
-    <div class="footer-bar">
-        <div class="footer-left">
-            <span><span class="status-dot"></span> AI Engine Online</span>
-            <span>Model: {model_used}</span>
-        </div>
-        <span>Last Sync: {now_utc}</span>
-    </div>
-    """, unsafe_allow_html=True)
 
 
 # ── Main ──────────────────────────────────────────────────────────────────────

--- a/frontend/app.py
+++ b/frontend/app.py
@@ -641,6 +641,76 @@ def inject_css():
         color: var(--on-surface); line-height: 1.4;
     }
 
+    /* Reconciled banner */
+    .reconciled-banner {
+        background: #fffbeb; border: 1px solid #f59e0b;
+        border-left: 6px solid #f59e0b;
+        border-radius: 8px; padding: 16px 20px;
+        margin-bottom: 20px;
+        display: flex; align-items: flex-start; gap: 12px;
+    }
+    .reconciled-icon { font-size: 20px; flex-shrink: 0; margin-top: 1px; }
+    .reconciled-title {
+        font-size: 13px; font-weight: 700; color: #92400e; margin-bottom: 4px;
+    }
+    .reconciled-body { font-size: 13px; color: #78350f; line-height: 1.5; }
+
+    /* Flags */
+    .flags-section {
+        margin-bottom: 20px;
+    }
+    .flag-item {
+        display: flex; align-items: flex-start; gap: 10px;
+        background: rgba(255,218,214,0.25);
+        border: 1px solid rgba(187,27,33,0.2);
+        border-radius: 8px; padding: 12px 16px;
+        margin-bottom: 8px; font-size: 13px;
+        color: var(--on-error-container); line-height: 1.5;
+    }
+    .flag-icon { flex-shrink: 0; font-size: 14px; margin-top: 1px; }
+
+    /* Clinical rationale */
+    .rationale-section {
+        background: var(--surface-container-lowest);
+        border-radius: 12px; padding: 24px;
+        box-shadow: 0 1px 3px rgba(0,0,0,0.04);
+        margin-bottom: 20px;
+    }
+    .rationale-text {
+        font-size: 14px; color: var(--on-surface);
+        line-height: 1.75; white-space: pre-wrap;
+    }
+
+    /* Similar cases table */
+    .cases-section {
+        background: var(--surface-container-lowest);
+        border-radius: 12px; padding: 24px;
+        box-shadow: 0 1px 3px rgba(0,0,0,0.04);
+        margin-bottom: 20px;
+    }
+    .cases-table { width: 100%; border-collapse: collapse; font-size: 12px; }
+    .cases-table th {
+        font-family: 'Public Sans', sans-serif;
+        font-size: 10px; font-weight: 700; text-transform: uppercase;
+        letter-spacing: 1px; color: var(--on-surface-variant);
+        padding: 8px 10px; border-bottom: 1px solid var(--outline-variant);
+        text-align: left;
+    }
+    .cases-table td {
+        padding: 10px 10px; color: var(--on-surface);
+        border-bottom: 1px solid var(--surface-container);
+        vertical-align: top;
+    }
+    .cases-table tr:last-child td { border-bottom: none; }
+    .esi-badge {
+        display: inline-block; font-weight: 700; font-size: 11px;
+        padding: 2px 8px; border-radius: 4px;
+    }
+    .esi-1 { background: var(--tertiary-fixed); color: var(--tertiary); }
+    .esi-2 { background: var(--primary-fixed); color: var(--primary); }
+    .esi-3 { background: var(--surface-container-highest); color: var(--secondary); }
+    .sim-score { font-weight: 600; color: var(--primary); }
+
     /* Footer status bar */
     .footer-bar {
         display: flex; justify-content: space-between;
@@ -1041,6 +1111,14 @@ def render_results_page():
     safety_reason = triage_result.get("safety_reason", None)
     top_features = triage_result.get("top_features", [])
 
+    # Agentic pipeline enriched fields
+    reconciled_label = triage_result.get("reconciled_label")
+    llm_agreement = triage_result.get("llm_agreement")
+    llm_esi = triage_result.get("llm_esi")
+    clinical_rationale = triage_result.get("clinical_rationale")
+    similar_cases = triage_result.get("similar_cases") or []
+    flags = triage_result.get("flags") or []
+
     # Derive UI data from real backend response
     drivers = shap_features_to_drivers(top_features)
     recommendations = label_to_recommendations(predicted_label)
@@ -1086,6 +1164,31 @@ def render_results_page():
     # Safety flag banner
     if safety_flag and safety_reason:
         st.warning(f"\u26a0\ufe0f **Safety Alert:** {safety_reason}")
+
+    # Reconciled label banner — shown when LLM disagrees with model
+    if llm_agreement is False and reconciled_label and reconciled_label != predicted_label:
+        esi_num = llm_esi or "?"
+        st.markdown(f"""
+        <div class="reconciled-banner">
+            <div class="reconciled-icon">&#9888;</div>
+            <div>
+                <div class="reconciled-title">LLM CLINICAL OVERRIDE — Effective Recommendation: {reconciled_label}</div>
+                <div class="reconciled-body">
+                    The model predicted <strong>{predicted_label}</strong>, but independent LLM reasoning
+                    recommended ESI {esi_num} (<strong>{reconciled_label}</strong>).
+                    The more cautious level (<strong>{reconciled_label}</strong>) is used for protocol selection.
+                </div>
+            </div>
+        </div>
+        """, unsafe_allow_html=True)
+
+    # Escalation flags
+    if flags:
+        flag_items = "".join(
+            f'<div class="flag-item"><span class="flag-icon">&#9873;</span>{f}</div>'
+            for f in flags
+        )
+        st.markdown(f'<div class="flags-section">{flag_items}</div>', unsafe_allow_html=True)
 
     left_col, right_col = st.columns([7, 5], gap="large")
 
@@ -1242,6 +1345,57 @@ def render_results_page():
                     del st.session_state[key]
             st.session_state.page = "intake"
             st.rerun()
+
+    # Clinical Rationale
+    if clinical_rationale:
+        st.markdown("""
+        <div class="rationale-section">
+            <div class="confidence-title">Clinical Rationale (LLM Analysis)</div>
+        """, unsafe_allow_html=True)
+        st.markdown(f'<div class="rationale-text">{clinical_rationale}</div>', unsafe_allow_html=True)
+        st.markdown("</div>", unsafe_allow_html=True)
+
+    # Similar Historical Cases
+    if similar_cases:
+        rows = ""
+        for c in similar_cases:
+            esi = c.get("triage_level", "?")
+            esi_cls = f"esi-{esi}" if esi in (1, 2, 3) else "esi-3"
+            hr = f"{c['heart_rate']:.0f}" if c.get("heart_rate") else "—"
+            sbp = c.get("sbp"); dbp = c.get("dbp")
+            bp = f"{sbp:.0f}/{dbp:.0f}" if sbp and dbp else "—"
+            spo2 = f"{c['spo2']:.0f}%" if c.get("spo2") else "—"
+            rows += f"""
+            <tr>
+                <td><span class="sim-score">{c.get('similarity', 0):.2f}</span></td>
+                <td><span class="esi-badge {esi_cls}">ESI {esi}</span></td>
+                <td>{c.get('chief_complaint') or '—'}</td>
+                <td>{hr}</td>
+                <td>{bp}</td>
+                <td>{spo2}</td>
+                <td>{c.get('diagnosis') or '—'}</td>
+                <td>{c.get('outcome') or '—'}</td>
+            </tr>"""
+        st.markdown(f"""
+        <div class="cases-section">
+            <div class="confidence-title">Similar Historical Cases (RAG)</div>
+            <table class="cases-table">
+                <thead>
+                    <tr>
+                        <th>Similarity</th>
+                        <th>ESI</th>
+                        <th>Chief Complaint</th>
+                        <th>HR</th>
+                        <th>BP</th>
+                        <th>SpO2</th>
+                        <th>Diagnosis</th>
+                        <th>Outcome</th>
+                    </tr>
+                </thead>
+                <tbody>{rows}</tbody>
+            </table>
+        </div>
+        """, unsafe_allow_html=True)
 
     # Footer — show actual model_used from backend response
     now_utc = datetime.now(timezone.utc).strftime("%H:%M:%S UTC")

--- a/frontend/app.py
+++ b/frontend/app.py
@@ -770,21 +770,9 @@ def inject_css():
     /* Hide text area label */
     [data-testid="stTextArea"] label { display: none !important; }
 
-    /* ── Force sidebar to always be visible ────────────────────── */
-    /* Override Streamlit's collapsed transform so sidebar is always open */
-    section[data-testid="stSidebar"] {
-        min-width: 244px !important;
-        transform: none !important;
-        left: 0 !important;
-        visibility: visible !important;
-    }
-    /* Hide only the buttons that trigger collapsing — not the reopen chevron */
+    /* ── Hide sidebar entirely ──────────────────────────────────── */
+    section[data-testid="stSidebar"],
     [data-testid="stSidebarCollapseButton"],
-    button[aria-label="Close sidebar"],
-    button[aria-label="Collapse sidebar"] {
-        display: none !important;
-    }
-    /* Also hide the floating reopen chevron (sidebar is always open now) */
     [data-testid="collapsedControl"] {
         display: none !important;
     }
@@ -856,7 +844,7 @@ def render_sidebar():
             if st.button("\U0001f464  Patient Intake", key="nav_intake_btn", use_container_width=True):
                 for key in ["triage_notes", "age", "heart_rate", "resp_rate",
                             "sbp", "dbp", "spo2", "temp_f", "pain",
-                            "arrival_transport", "form_data", "triage_result"]:
+                            "arrival_transport", "form_data", "triage_result", "is_loading"]:
                     if key in st.session_state:
                         del st.session_state[key]
                 st.session_state.page = "intake"
@@ -883,6 +871,11 @@ def render_sidebar():
 # ── Page 1: Intake form ──────────────────────────────────────────────────────
 
 def render_intake_page():
+    import json as _json
+    import threading, time as _time
+
+    is_loading = st.session_state.get("is_loading", False)
+
     st.markdown("""
     <div class="top-header">
         <div class="top-header-left">
@@ -898,139 +891,196 @@ def render_intake_page():
     </div>
     """, unsafe_allow_html=True)
 
-    # ── Patient Info ─────────────────────────────────────────────
-    st.markdown('<div class="intake-section-title">Patient Information</div>', unsafe_allow_html=True)
-    c1, c2, c3 = st.columns([2, 2, 1])
-    with c1:
-        st.markdown('<div class="field-label">First Name</div>', unsafe_allow_html=True)
-        st.text_input("First Name", key="first_name", placeholder="Jane", label_visibility="collapsed")
-    with c2:
-        st.markdown('<div class="field-label">Last Name</div>', unsafe_allow_html=True)
-        st.text_input("Last Name", key="last_name", placeholder="Smith", label_visibility="collapsed")
-    with c3:
-        st.markdown('<div class="field-label">Age</div>', unsafe_allow_html=True)
-        st.number_input("Age", min_value=0, max_value=120, value=None, key="age",
-                        placeholder="—", label_visibility="collapsed")
+    # ── Collapsed summary shown while loading ─────────────────────
+    if is_loading:
+        fd = st.session_state.get("form_data", {})
+        first = fd.get("first_name", "").strip()
+        last  = fd.get("last_name", "").strip()
+        name  = f"{first} {last}".strip() or "Patient"
+        age   = fd.get("age")
+        notes = fd.get("triage_notes", "")[:120]
+        age_str = f", {age}y" if age else ""
+        st.markdown(f"""
+        <div style="background:#f8fafc;border:1px solid #dde3ed;border-radius:12px;
+                    padding:16px 20px;margin-bottom:16px;
+                    display:flex;align-items:center;gap:16px;">
+            <div style="font-size:28px;">&#128100;</div>
+            <div>
+                <div style="font-size:14px;font-weight:700;color:#0f172a;">{name}{age_str}</div>
+                <div style="font-size:12px;color:#64748b;margin-top:2px;">{notes}{"..." if len(fd.get("triage_notes","")) > 120 else ""}</div>
+            </div>
+        </div>
+        """, unsafe_allow_html=True)
+    else:
+        # ── Patient Info ─────────────────────────────────────────
+        st.markdown('<div class="intake-section-title">Patient Information</div>', unsafe_allow_html=True)
+        c1, c2, c3 = st.columns([2, 2, 1])
+        with c1:
+            st.markdown('<div class="field-label">First Name</div>', unsafe_allow_html=True)
+            st.text_input("First Name", key="first_name", placeholder="Jane", label_visibility="collapsed")
+        with c2:
+            st.markdown('<div class="field-label">Last Name</div>', unsafe_allow_html=True)
+            st.text_input("Last Name", key="last_name", placeholder="Smith", label_visibility="collapsed")
+        with c3:
+            st.markdown('<div class="field-label">Age</div>', unsafe_allow_html=True)
+            st.number_input("Age", min_value=0, max_value=120, value=None, key="age",
+                            placeholder="—", label_visibility="collapsed")
 
-    # ── Triage Notes ─────────────────────────────────────────────
-    st.markdown('<div class="intake-section-title">Triage Notes</div>', unsafe_allow_html=True)
-    st.text_area(
-        "Triage Notes", height=160, key="triage_notes",
-        placeholder="Chief complaint, symptoms, relevant history...",
-        label_visibility="collapsed",
-    )
+        # ── Triage Notes ─────────────────────────────────────────
+        st.markdown('<div class="intake-section-title">Triage Notes</div>', unsafe_allow_html=True)
+        st.text_area(
+            "Triage Notes", height=160, key="triage_notes",
+            placeholder="Chief complaint, symptoms, relevant history...",
+            label_visibility="collapsed",
+        )
 
-    # ── Vitals ───────────────────────────────────────────────────
-    st.markdown('<div class="intake-section-title">Vitals</div>', unsafe_allow_html=True)
-    v1, v2, v3, v4, v5, v6 = st.columns(6)
-    with v1:
-        st.markdown('<div class="field-label">Heart Rate</div>', unsafe_allow_html=True)
-        st.number_input("HR", min_value=20, max_value=250, value=None, key="heart_rate",
-                        placeholder="BPM", label_visibility="collapsed")
-    with v2:
-        st.markdown('<div class="field-label">Resp Rate</div>', unsafe_allow_html=True)
-        st.number_input("RR", min_value=4, max_value=60, value=None, key="resp_rate",
-                        placeholder="br/m", label_visibility="collapsed")
-    with v3:
-        st.markdown('<div class="field-label">SBP</div>', unsafe_allow_html=True)
-        st.number_input("SBP", min_value=40, max_value=300, value=None, key="sbp",
-                        placeholder="mmHg", label_visibility="collapsed")
-    with v4:
-        st.markdown('<div class="field-label">DBP</div>', unsafe_allow_html=True)
-        st.number_input("DBP", min_value=10, max_value=200, value=None, key="dbp",
-                        placeholder="mmHg", label_visibility="collapsed")
-    with v5:
-        st.markdown('<div class="field-label">SpO2</div>', unsafe_allow_html=True)
-        st.number_input("SpO2", min_value=50, max_value=100, value=None, key="spo2",
-                        placeholder="%", label_visibility="collapsed")
-    with v6:
-        st.markdown('<div class="field-label">Temp (°F)</div>', unsafe_allow_html=True)
-        st.number_input("Temp", min_value=85.0, max_value=115.0, value=None, key="temp_f",
-                        placeholder="°F", step=0.1, label_visibility="collapsed")
+        # ── Vitals ───────────────────────────────────────────────
+        st.markdown('<div class="intake-section-title">Vitals</div>', unsafe_allow_html=True)
+        v1, v2, v3, v4, v5, v6 = st.columns(6)
+        with v1:
+            st.markdown('<div class="field-label">Heart Rate</div>', unsafe_allow_html=True)
+            st.number_input("HR", min_value=20, max_value=250, value=None, key="heart_rate",
+                            placeholder="BPM", label_visibility="collapsed")
+        with v2:
+            st.markdown('<div class="field-label">Resp Rate</div>', unsafe_allow_html=True)
+            st.number_input("RR", min_value=4, max_value=60, value=None, key="resp_rate",
+                            placeholder="br/m", label_visibility="collapsed")
+        with v3:
+            st.markdown('<div class="field-label">SBP</div>', unsafe_allow_html=True)
+            st.number_input("SBP", min_value=40, max_value=300, value=None, key="sbp",
+                            placeholder="mmHg", label_visibility="collapsed")
+        with v4:
+            st.markdown('<div class="field-label">DBP</div>', unsafe_allow_html=True)
+            st.number_input("DBP", min_value=10, max_value=200, value=None, key="dbp",
+                            placeholder="mmHg", label_visibility="collapsed")
+        with v5:
+            st.markdown('<div class="field-label">SpO2</div>', unsafe_allow_html=True)
+            st.number_input("SpO2", min_value=50, max_value=100, value=None, key="spo2",
+                            placeholder="%", label_visibility="collapsed")
+        with v6:
+            st.markdown('<div class="field-label">Temp (°F)</div>', unsafe_allow_html=True)
+            st.number_input("Temp", min_value=85.0, max_value=115.0, value=None, key="temp_f",
+                            placeholder="°F", step=0.1, label_visibility="collapsed")
 
-    # ── Pain + Transport ─────────────────────────────────────────
-    st.markdown('<div class="intake-section-title">Assessment</div>', unsafe_allow_html=True)
-    p_col, t_col = st.columns([3, 1])
-    with p_col:
-        pain_val = st.session_state.get("pain", 4)
-        st.markdown(f'<div class="field-label">Pain Level &nbsp;<span style="color:var(--primary);font-weight:700;">{pain_val} / 10</span></div>', unsafe_allow_html=True)
-        st.slider("Pain", min_value=0, max_value=10, value=4, key="pain", label_visibility="collapsed")
-    with t_col:
-        st.markdown('<div class="field-label">Arrival Transport</div>', unsafe_allow_html=True)
-        st.selectbox("Transport", TRANSPORT_OPTIONS, key="arrival_transport", label_visibility="collapsed")
+        # ── Pain + Transport ─────────────────────────────────────
+        st.markdown('<div class="intake-section-title">Assessment</div>', unsafe_allow_html=True)
+        p_col, t_col = st.columns([3, 1])
+        with p_col:
+            pain_val = st.session_state.get("pain", 4)
+            st.markdown(f'<div class="field-label">Pain Level &nbsp;<span style="color:var(--primary);font-weight:700;">{pain_val} / 10</span></div>', unsafe_allow_html=True)
+            st.slider("Pain", min_value=0, max_value=10, value=4, key="pain", label_visibility="collapsed")
+        with t_col:
+            st.markdown('<div class="field-label">Arrival Transport</div>', unsafe_allow_html=True)
+            st.selectbox("Transport", TRANSPORT_OPTIONS, key="arrival_transport", label_visibility="collapsed")
 
-    # Submit button
+    # ── Submit button (disabled while loading) ───────────────────
     _l, center, _r = st.columns([2, 3, 2])
     with center:
-        if st.button("Run Triage Assessment", type="primary",
-                     use_container_width=True, key="submit_btn"):
-            form_data = {
-                "first_name": st.session_state.get("first_name", ""),
-                "last_name": st.session_state.get("last_name", ""),
-                "triage_notes": st.session_state.get("triage_notes", ""),
-                "age": st.session_state.get("age"),
-                "heart_rate": st.session_state.get("heart_rate"),
-                "resp_rate": st.session_state.get("resp_rate"),
-                "sbp": st.session_state.get("sbp"),
-                "dbp": st.session_state.get("dbp"),
-                "spo2": st.session_state.get("spo2"),
-                "temp_f": st.session_state.get("temp_f"),
-                "pain": st.session_state.get("pain", 4),
-                "arrival_transport": st.session_state.get(
-                    "arrival_transport", "Walk In"),
-            }
-            st.session_state.form_data = form_data
+        clicked = st.button(
+            "Analyzing..." if is_loading else "Run Triage Assessment",
+            type="primary",
+            use_container_width=True,
+            key="submit_btn",
+            disabled=is_loading,
+        )
 
-            # POST to /predict — exclude display-only fields from ML payload
-            with st.spinner("Analyzing triage data..."):
-                try:
-                    _backend_keys = {"triage_notes", "age", "heart_rate", "resp_rate",
-                                     "sbp", "dbp", "spo2", "temp_f", "pain", "arrival_transport"}
-                    payload = {k: v for k, v in form_data.items()
-                               if k in _backend_keys and v is not None}
-                    import json as _json
-                    print(f"[TriagePulse] → POST {BACKEND_URL}/predict")
-                    print(f"[TriagePulse]   payload: {_json.dumps(payload, indent=2)}")
-                    resp = requests.post(
-                        f"{BACKEND_URL}/predict",
-                        json=payload,
-                        timeout=30,
-                    )
-                    resp.raise_for_status()
-                    triage_result = resp.json()
-                    print(f"[TriagePulse] ← {resp.status_code} response:")
-                    print(f"[TriagePulse]   {_json.dumps(triage_result, indent=2)}")
-                except requests.exceptions.ConnectionError:
-                    st.error(
-                        f"Cannot reach the backend at {BACKEND_URL}. "
-                        "Make sure `uvicorn backend.main:app --reload --port 8000` is running."
-                    )
-                    st.stop()
-                except requests.exceptions.HTTPError as exc:
-                    st.error(
-                        f"Backend returned an error: "
-                        f"{exc.response.status_code} — {exc.response.text}"
-                    )
-                    st.stop()
-                except Exception as exc:
-                    st.error(f"Unexpected error calling backend: {exc}")
-                    st.stop()
+        # Status steps shown directly below the button
+        status_box = st.empty()
 
-            # Store result in session state
-            st.session_state.triage_result = triage_result
+    if clicked and not is_loading:
+        form_data = {
+            "first_name": st.session_state.get("first_name", ""),
+            "last_name": st.session_state.get("last_name", ""),
+            "triage_notes": st.session_state.get("triage_notes", ""),
+            "age": st.session_state.get("age"),
+            "heart_rate": st.session_state.get("heart_rate"),
+            "resp_rate": st.session_state.get("resp_rate"),
+            "sbp": st.session_state.get("sbp"),
+            "dbp": st.session_state.get("dbp"),
+            "spo2": st.session_state.get("spo2"),
+            "temp_f": st.session_state.get("temp_f"),
+            "pain": st.session_state.get("pain", 4),
+            "arrival_transport": st.session_state.get("arrival_transport", "Walk In"),
+        }
+        st.session_state.form_data = form_data
+        st.session_state.is_loading = True
+        st.rerun()
 
-            # Append to history (keep last 20)
-            history_entry = {
-                "timestamp": datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC"),
-                "triage_notes": form_data.get("triage_notes", ""),
-                "result": triage_result,
-            }
-            st.session_state.triage_history.insert(0, history_entry)
-            if len(st.session_state.triage_history) > 20:
-                st.session_state.triage_history = st.session_state.triage_history[:20]
+    if is_loading:
+        _backend_keys = {"triage_notes", "age", "heart_rate", "resp_rate",
+                         "sbp", "dbp", "spo2", "temp_f", "pain", "arrival_transport"}
+        form_data = st.session_state.get("form_data", {})
+        payload = {k: v for k, v in form_data.items()
+                   if k in _backend_keys and v is not None}
 
-            st.session_state.page = "results"
-            st.rerun()
+        result_holder = {}
+
+        def _do_request():
+            try:
+                r = requests.post(f"{BACKEND_URL}/predict", json=payload, timeout=120)
+                r.raise_for_status()
+                result_holder["data"] = r.json()
+            except Exception as e:
+                result_holder["error"] = e
+
+        thread = threading.Thread(target=_do_request)
+        thread.start()
+
+        steps = [
+            ("🔬", "Running ML model inference..."),
+            ("🔍", "Retrieving similar historical cases..."),
+            ("🧠", "LLM clinical analysis in progress..."),
+            ("📋", "Synthesizing triage recommendation..."),
+        ]
+        step_idx = 0
+        while thread.is_alive():
+            icon, msg = steps[min(step_idx, len(steps) - 1)]
+            status_box.markdown(f"""
+            <div style="display:flex;align-items:center;gap:14px;padding:16px 20px;
+                        background:#f0f6ff;border-radius:10px;border:1px solid #c7d9f5;
+                        margin-top:12px;">
+                <div style="font-size:22px">{icon}</div>
+                <div>
+                    <div style="font-size:13px;font-weight:600;color:#1d4ed8;">{msg}</div>
+                    <div style="font-size:11px;color:#64748b;margin-top:2px;">
+                        Step {min(step_idx+1, len(steps))} of {len(steps)}
+                    </div>
+                </div>
+            </div>
+            """, unsafe_allow_html=True)
+            _time.sleep(4)
+            step_idx += 1
+
+        thread.join()
+        status_box.empty()
+        st.session_state.is_loading = False
+
+        if "error" in result_holder:
+            exc = result_holder["error"]
+            if isinstance(exc, requests.exceptions.ConnectionError):
+                st.error(f"Cannot reach the backend at {BACKEND_URL}. "
+                         "Make sure `uvicorn backend.main:app --reload --port 8000` is running.")
+            elif isinstance(exc, requests.exceptions.HTTPError):
+                st.error(f"Backend returned an error: {exc.response.status_code} — {exc.response.text}")
+            else:
+                st.error(f"Unexpected error: {exc}")
+            st.stop()
+
+        triage_result = result_holder["data"]
+        print(f"[TriagePulse] ← response: {_json.dumps(triage_result, indent=2)}")
+
+        st.session_state.triage_result = triage_result
+        history_entry = {
+            "timestamp": datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC"),
+            "triage_notes": form_data.get("triage_notes", ""),
+            "result": triage_result,
+        }
+        st.session_state.triage_history.insert(0, history_entry)
+        if len(st.session_state.triage_history) > 20:
+            st.session_state.triage_history = st.session_state.triage_history[:20]
+
+        st.session_state.page = "results"
+        st.rerun()
 
 
 # ── Page 2: Results ──────────────────────────────────────────────────────────
@@ -1066,43 +1116,29 @@ def render_results_page():
 
     # Derive UI data from real backend response
     drivers = shap_features_to_drivers(top_features)
-    recommendations = label_to_recommendations(predicted_label)
 
-    # Patient vitals from submitted form_data
-    hr_val = form_data.get("heart_rate")
-    sbp_val = form_data.get("sbp")
-    dbp_val = form_data.get("dbp")
-    age_val = form_data.get("age")
-    hr_display = str(hr_val) if hr_val is not None else "—"
-    bp_display = (
-        f"{sbp_val}/{dbp_val}"
-        if sbp_val is not None and dbp_val is not None
-        else "—"
-    )
-    age_display = f"{age_val}Y" if age_val is not None else ""
-
-    # Parse label for display (e.g. "L1-Critical" → level_code="L1", level_desc="CRITICAL")
+    # Parse label
     label_parts = predicted_label.split("-", 1)
     level_code = label_parts[0] if label_parts else predicted_label
     level_desc = label_parts[1].upper() if len(label_parts) > 1 else ""
 
-    # Breadcrumb + header
-    st.markdown("""
-    <div style="display: flex; justify-content: space-between; align-items: flex-start; margin-bottom: 24px;">
-        <div>
-            <div class="breadcrumb">
-                TRIAGE WORKFLOW &nbsp;&#8250;&nbsp; PATIENT ASSESSMENT &nbsp;&#8250;&nbsp;
-                <span class="active">ANALYSIS RESULT</span>
-            </div>
-            <div class="results-title">Diagnostic Output</div>
+    # ── Collapsed patient header ──────────────────────────────────
+    first_name = form_data.get("first_name", "").strip()
+    last_name  = form_data.get("last_name", "").strip()
+    patient_name = f"{first_name} {last_name}".strip() or "Patient"
+    age_val = form_data.get("age")
+    notes_preview = form_data.get("triage_notes", "")[:120]
+    age_str = f", {age_val}y" if age_val else ""
+    st.markdown(f"""
+    <div style="background:#f8fafc;border:1px solid #dde3ed;border-radius:12px;
+                padding:16px 20px;margin-bottom:20px;
+                display:flex;align-items:center;gap:16px;">
+        <div style="font-size:28px;">&#128100;</div>
+        <div style="flex:1;">
+            <div style="font-size:14px;font-weight:700;color:#0f172a;">{patient_name}{age_str}</div>
+            <div style="font-size:12px;color:#64748b;margin-top:2px;">{notes_preview}{"..." if len(form_data.get("triage_notes","")) > 120 else ""}</div>
         </div>
-        <div class="assigned-to">
-            <div class="avatar" style="width:36px;height:36px;">&#128105;&#8205;&#9877;</div>
-            <div>
-                <div class="assigned-label">Assigned To</div>
-                <div class="assigned-name">Dr. Aris Thorne</div>
-            </div>
-        </div>
+        <div style="font-size:11px;color:#94a3b8;">{datetime.now(timezone.utc).strftime("%H:%M UTC")}</div>
     </div>
     """, unsafe_allow_html=True)
 
@@ -1110,7 +1146,7 @@ def render_results_page():
     if safety_flag and safety_reason:
         st.warning(f"\u26a0\ufe0f **Safety Alert:** {safety_reason}")
 
-    # Reconciled label banner — shown when LLM disagrees with model
+    # Reconciled label banner
     if llm_agreement is False and reconciled_label and reconciled_label != predicted_label:
         esi_num = llm_esi or "?"
         st.markdown(f"""
@@ -1121,7 +1157,7 @@ def render_results_page():
                 <div class="reconciled-body">
                     The model predicted <strong>{predicted_label}</strong>, but independent LLM reasoning
                     recommended ESI {esi_num} (<strong>{reconciled_label}</strong>).
-                    The more cautious level (<strong>{reconciled_label}</strong>) is used for protocol selection.
+                    The more cautious level is used for protocol selection.
                 </div>
             </div>
         </div>
@@ -1135,161 +1171,112 @@ def render_results_page():
         )
         st.markdown(f'<div class="flags-section">{flag_items}</div>', unsafe_allow_html=True)
 
-    left_col, right_col = st.columns([7, 5], gap="large")
-
-    with left_col:
-        # Priority card — derived from predicted_label
-        st.markdown(f"""
-        <div class="priority-card">
-            <div class="priority-content">
-                <div class="priority-badge">PREDICTED PRIORITY</div>
-                <div class="priority-level">{level_code} -<br>{level_desc}</div>
-                <div class="priority-desc">
-                    Model: <strong>{model_used}</strong>. Based on submitted vitals and
-                    triage notes, the system classified this patient as
-                    <strong>{predicted_label}</strong>.
-                </div>
+    # ── Priority card (smaller, full width) ───────────────────────
+    st.markdown(f"""
+    <div style="background:#fff;border-radius:12px;border-left:5px solid var(--tertiary);
+                box-shadow:0 1px 3px rgba(0,0,0,0.06);
+                display:flex;align-items:center;gap:0;margin-bottom:20px;overflow:hidden;">
+        <div style="padding:20px 28px;flex:1;">
+            <div style="font-family:'Public Sans',sans-serif;font-size:10px;font-weight:700;
+                        color:var(--tertiary);background:var(--tertiary-fixed);
+                        padding:3px 8px;border-radius:4px;display:inline-block;margin-bottom:10px;">
+                PREDICTED PRIORITY
             </div>
-            <div class="target-zone">
-                <div class="target-icon">&#9888;</div>
-                <div class="target-label">Predicted Class</div>
-                <div class="target-name">{predicted_label}</div>
+            <div style="font-size:36px;font-weight:900;color:var(--tertiary);
+                        letter-spacing:-1px;line-height:1;margin-bottom:6px;">
+                {level_code} — {level_desc}
+            </div>
+            <div style="font-size:13px;color:var(--on-surface-variant);">
+                Model: <strong>{model_used}</strong> &nbsp;·&nbsp; Classified as <strong>{predicted_label}</strong>
             </div>
         </div>
-        """, unsafe_allow_html=True)
-
-        # Confidence + Drivers side by side
-        c_left, c_right = st.columns(2)
-
-        with c_left:
-            l1_pct = prob.get("L1-Critical", 0.0) * 100
-            l2_pct = prob.get("L2-Emergent", 0.0) * 100
-            l3_pct = prob.get("L3-Urgent/LessUrgent", 0.0) * 100
-            st.markdown(f"""
-            <div class="confidence-section">
-                <div class="confidence-title">Confidence Breakdown</div>
-                <div class="conf-row">
-                    <div class="conf-labels">
-                        <span class="conf-name critical">Level 1 (Critical)</span>
-                        <span class="conf-pct">{l1_pct:.1f}%</span>
-                    </div>
-                    <div class="conf-track lg">
-                        <div class="conf-fill critical" style="width:{l1_pct}%"></div>
-                    </div>
-                </div>
-                <div class="conf-row">
-                    <div class="conf-labels">
-                        <span class="conf-name muted">Level 2 (Emergent)</span>
-                        <span class="conf-pct muted">{l2_pct:.1f}%</span>
-                    </div>
-                    <div class="conf-track sm">
-                        <div class="conf-fill muted" style="width:{l2_pct}%"></div>
-                    </div>
-                </div>
-                <div class="conf-row">
-                    <div class="conf-labels">
-                        <span class="conf-name muted">Level 3 (Urgent)</span>
-                        <span class="conf-pct muted">{l3_pct:.1f}%</span>
-                    </div>
-                    <div class="conf-track sm">
-                        <div class="conf-fill faint" style="width:max(1%,{l3_pct}%)"></div>
-                    </div>
-                </div>
+        <div style="background:var(--tertiary-container);color:#ffceca;
+                    padding:20px 32px;text-align:center;min-width:160px;align-self:stretch;
+                    display:flex;flex-direction:column;justify-content:center;">
+            <div style="font-size:32px;margin-bottom:4px;">&#9888;</div>
+            <div style="font-family:'Public Sans',sans-serif;font-size:9px;font-weight:700;
+                        text-transform:uppercase;letter-spacing:2px;opacity:0.8;margin-bottom:2px;">
+                Predicted Class
             </div>
-            """, unsafe_allow_html=True)
+            <div style="font-size:16px;font-weight:700;">{predicted_label}</div>
+        </div>
+    </div>
+    """, unsafe_allow_html=True)
 
-        with c_right:
-            drivers_items = []
-            for d in drivers:
-                bg_cls = "critical-bg" if d["critical"] else "normal-bg"
-                icon_cls = "critical" if d["critical"] else "primary"
-                title_cls = "critical" if d["critical"] else "normal"
-                drivers_items.append(
-                    f'<div class="driver-item {bg_cls}">'
-                    f'<span class="driver-icon {icon_cls}">{d["icon"]}</span>'
-                    f'<div>'
-                    f'<div class="driver-title {title_cls}">{d["title"]}</div>'
-                    f'<div class="driver-detail">{d["detail"]}</div>'
-                    f'</div></div>'
-                )
-            drivers_html = "".join(drivers_items) if drivers_items else (
-                "<p style='color:var(--on-surface-variant);font-size:13px;'>"
-                "No SHAP feature data available.</p>"
-            )
-            st.markdown(
-                f'<div class="drivers-section">'
-                f'<div class="confidence-title">Clinical Drivers</div>'
-                f'{drivers_html}'
-                f'</div>',
-                unsafe_allow_html=True,
-            )
+    # ── Confidence + Drivers ──────────────────────────────────────
+    c_left, c_right = st.columns(2)
 
-    with right_col:
-        # Patient mini-profile derived from submitted form_data
-        first_name = form_data.get("first_name", "").strip()
-        last_name = form_data.get("last_name", "").strip()
-        if first_name or last_name:
-            patient_name = f"{first_name} {last_name}".strip()
-        else:
-            patient_name = "Current Patient"
+    with c_left:
+        l1_pct = prob.get("L1-Critical", 0.0) * 100
+        l2_pct = prob.get("L2-Emergent", 0.0) * 100
+        l3_pct = prob.get("L3-Urgent/LessUrgent", 0.0) * 100
         st.markdown(f"""
-        <div class="patient-card">
-            <div class="patient-header">
-                <div class="patient-avatar">&#128100;</div>
-                <div>
-                    <div class="patient-name">{patient_name}</div>
-                    <div class="patient-meta">{age_display} &bull; Submitted {datetime.now(timezone.utc).strftime("%H:%M UTC")}</div>
+        <div class="confidence-section">
+            <div class="confidence-title">Confidence Breakdown</div>
+            <div class="conf-row">
+                <div class="conf-labels">
+                    <span class="conf-name critical">Level 1 (Critical)</span>
+                    <span class="conf-pct">{l1_pct:.1f}%</span>
+                </div>
+                <div class="conf-track lg">
+                    <div class="conf-fill critical" style="width:{l1_pct}%"></div>
                 </div>
             </div>
-            <div class="vitals-grid">
-                <div class="vital-display">
-                    <div class="vital-display-label">Heart Rate</div>
-                    <span class="vital-display-value">{hr_display}</span>
-                    <span class="vital-display-unit">BPM</span>
-                    <span class="vital-heart-icon">&#9829;</span>
+            <div class="conf-row">
+                <div class="conf-labels">
+                    <span class="conf-name muted">Level 2 (Emergent)</span>
+                    <span class="conf-pct muted">{l2_pct:.1f}%</span>
                 </div>
-                <div class="vital-display">
-                    <div class="vital-display-label">BP (Sys/Dia)</div>
-                    <span class="vital-display-value">{bp_display}</span>
-                    <span class="vital-display-unit">mmHg</span>
+                <div class="conf-track sm">
+                    <div class="conf-fill muted" style="width:{l2_pct}%"></div>
+                </div>
+            </div>
+            <div class="conf-row">
+                <div class="conf-labels">
+                    <span class="conf-name muted">Level 3 (Urgent)</span>
+                    <span class="conf-pct muted">{l3_pct:.1f}%</span>
+                </div>
+                <div class="conf-track sm">
+                    <div class="conf-fill faint" style="width:max(1%,{l3_pct}%)"></div>
                 </div>
             </div>
         </div>
         """, unsafe_allow_html=True)
 
-        # Protocol recommendations — derived from predicted_label
-        rec_items = []
-        for r in recommendations:
-            rec_items.append(
-                f'<div class="rec-item">'
-                f'<div class="rec-check">\u2713</div>'
-                f'<div class="rec-text">{r}</div>'
-                f'</div>'
+    with c_right:
+        drivers_items = []
+        for d in drivers:
+            bg_cls = "critical-bg" if d["critical"] else "normal-bg"
+            icon_cls = "critical" if d["critical"] else "primary"
+            title_cls = "critical" if d["critical"] else "normal"
+            drivers_items.append(
+                f'<div class="driver-item {bg_cls}">'
+                f'<span class="driver-icon {icon_cls}">{d["icon"]}</span>'
+                f'<div>'
+                f'<div class="driver-title {title_cls}">{d["title"]}</div>'
+                f'<div class="driver-detail">{d["detail"]}</div>'
+                f'</div></div>'
             )
-        recs_html = "".join(rec_items)
+        drivers_html = "".join(drivers_items) if drivers_items else (
+            "<p style='color:var(--on-surface-variant);font-size:13px;'>No SHAP feature data available.</p>"
+        )
         st.markdown(
-            f'<div class="rec-section">'
-            f'<div class="rec-title">Protocol Recommendations</div>'
-            f'{recs_html}'
+            f'<div class="drivers-section">'
+            f'<div class="confidence-title">Clinical Drivers</div>'
+            f'{drivers_html}'
             f'</div>',
             unsafe_allow_html=True,
         )
 
-        # Action buttons
-        if st.button("Confirm and Record Triage", type="primary",
-                     use_container_width=True, key="confirm_btn"):
-            pass  # History already appended on submit
-
-        if st.button("Triage Another Patient", use_container_width=True,
-                     key="restart_btn"):
-            # Clear form/result data but keep triage_history
-            for key in ["triage_notes", "age", "heart_rate", "resp_rate",
-                        "sbp", "dbp", "spo2", "temp_f", "pain",
-                        "arrival_transport", "form_data", "triage_result"]:
-                if key in st.session_state:
-                    del st.session_state[key]
-            st.session_state.page = "intake"
-            st.rerun()
+    # ── Action button ─────────────────────────────────────────────
+    if st.button("Triage Another Patient", use_container_width=True, key="restart_btn"):
+        for key in ["triage_notes", "age", "heart_rate", "resp_rate",
+                    "sbp", "dbp", "spo2", "temp_f", "pain",
+                    "arrival_transport", "form_data", "triage_result", "is_loading"]:
+            if key in st.session_state:
+                del st.session_state[key]
+        st.session_state.page = "intake"
+        st.rerun()
 
     # Clinical Rationale
     if clinical_rationale:
@@ -1371,7 +1358,6 @@ def main():
         st.session_state.triage_history = []
 
     inject_css()
-    render_sidebar()
 
     if st.session_state.page == "intake":
         render_intake_page()

--- a/frontend/app.py
+++ b/frontend/app.py
@@ -112,6 +112,19 @@ def inject_css():
     .stApp, [data-testid="stAppViewContainer"] {
         background-color: var(--surface) !important;
         font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif !important;
+        color: #171c22 !important;
+    }
+
+    /* Ensure all native Streamlit text elements are dark */
+    .stApp p:not(button p):not([data-testid="stButton"] p),
+    .stApp h1, .stApp h2, .stApp h3, .stApp label {
+        color: #171c22;
+    }
+
+    /* Restore white text on primary buttons */
+    [data-testid="stButton"] > button[kind="primary"] p,
+    [data-testid="stButton"] > button[kind="primary"] span {
+        color: white !important;
     }
 
     [data-testid="stHeader"] { background: transparent !important; }
@@ -815,6 +828,54 @@ def inject_css():
         border-right-color: #1d4ed8 !important;
         font-weight: 600 !important;
     }
+
+    /* ── Loading overlay ───────────────────────────────────────── */
+    .triage-overlay {
+        position: fixed;
+        inset: 0;
+        background: rgba(15, 23, 42, 0.55);
+        backdrop-filter: blur(3px);
+        z-index: 9999;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+    }
+    .triage-overlay-card {
+        background: #ffffff;
+        border-radius: 16px;
+        padding: 40px 48px;
+        width: 420px;
+        box-shadow: 0 20px 60px rgba(0,0,0,0.25);
+        text-align: center;
+    }
+    .overlay-title {
+        font-size: 17px;
+        font-weight: 700;
+        color: #0f172a;
+        margin-bottom: 6px;
+    }
+    .overlay-subtitle {
+        font-size: 13px;
+        color: #64748b;
+        margin-bottom: 28px;
+    }
+    .overlay-step {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        padding: 10px 0;
+        border-bottom: 1px solid #f1f5f9;
+        text-align: left;
+    }
+    .overlay-step:last-child { border-bottom: none; }
+    .overlay-step-icon { font-size: 18px; width: 28px; text-align: center; }
+    .overlay-step-text { font-size: 13px; flex: 1; }
+    .step-done   { color: #94a3b8; }
+    .step-done .overlay-step-text { text-decoration: line-through; }
+    .step-active { color: #1d4ed8; font-weight: 600; }
+    .step-pending { color: #cbd5e1; }
+    @keyframes pulse { 0%,100%{opacity:1} 50%{opacity:0.4} }
+    .step-active .overlay-step-icon { animation: pulse 1.2s ease-in-out infinite; }
     </style>
     """, unsafe_allow_html=True)
 
@@ -900,21 +961,29 @@ def render_intake_page():
         age   = fd.get("age")
         notes = fd.get("triage_notes", "")[:120]
         age_str = f", {age}y" if age else ""
-        st.markdown(f"""
-        <div style="background:#f8fafc;border:1px solid #dde3ed;border-radius:12px;
-                    padding:16px 20px;margin-bottom:16px;
-                    display:flex;align-items:center;gap:16px;">
-            <div style="font-size:28px;">&#128100;</div>
-            <div>
-                <div style="font-size:14px;font-weight:700;color:#0f172a;">{name}{age_str}</div>
-                <div style="font-size:12px;color:#64748b;margin-top:2px;">{notes}{"..." if len(fd.get("triage_notes","")) > 120 else ""}</div>
-            </div>
-        </div>
-        """, unsafe_allow_html=True)
+        st.markdown(f"👤 **{name}{age_str}**")
+        st.caption(notes + ("..." if len(fd.get("triage_notes", "")) > 120 else ""))
     else:
+        # ── Dev shortcut ─────────────────────────────────────────
+        if st.button("🧪 Fill Test Patient (Dorothy)", key="fill_test"):
+            st.session_state.first_name = "Dorothy"
+            st.session_state.last_name = "Williams"
+            st.session_state.age = 68
+            st.session_state.sex = "Female"
+            st.session_state.triage_notes = "Fever, confusion, and low blood pressure for the past 6 hours"
+            st.session_state.heart_rate = 118
+            st.session_state.resp_rate = 24
+            st.session_state.sbp = 88
+            st.session_state.dbp = 52
+            st.session_state.spo2 = 93
+            st.session_state.temp_f = 101.8
+            st.session_state.pain = 6
+            st.session_state.arrival_transport = "Ambulance"
+            st.rerun()
+
         # ── Patient Info ─────────────────────────────────────────
         st.markdown('<div class="intake-section-title">Patient Information</div>', unsafe_allow_html=True)
-        c1, c2, c3 = st.columns([2, 2, 1])
+        c1, c2, c3, c4 = st.columns([2, 2, 1, 1])
         with c1:
             st.markdown('<div class="field-label">First Name</div>', unsafe_allow_html=True)
             st.text_input("First Name", key="first_name", placeholder="Jane", label_visibility="collapsed")
@@ -925,6 +994,9 @@ def render_intake_page():
             st.markdown('<div class="field-label">Age</div>', unsafe_allow_html=True)
             st.number_input("Age", min_value=0, max_value=120, value=None, key="age",
                             placeholder="—", label_visibility="collapsed")
+        with c4:
+            st.markdown('<div class="field-label">Sex</div>', unsafe_allow_html=True)
+            st.selectbox("Sex", ["—", "Female", "Male", "Other"], key="sex", label_visibility="collapsed")
 
         # ── Triage Notes ─────────────────────────────────────────
         st.markdown('<div class="intake-section-title">Triage Notes</div>', unsafe_allow_html=True)
@@ -964,42 +1036,45 @@ def render_intake_page():
 
         # ── Pain + Transport ─────────────────────────────────────
         st.markdown('<div class="intake-section-title">Assessment</div>', unsafe_allow_html=True)
-        p_col, t_col = st.columns([3, 1])
+        p_col, t_col = st.columns([1, 3])
         with p_col:
-            pain_val = st.session_state.get("pain", 4)
-            st.markdown(f'<div class="field-label">Pain Level &nbsp;<span style="color:var(--primary);font-weight:700;">{pain_val} / 10</span></div>', unsafe_allow_html=True)
-            st.slider("Pain", min_value=0, max_value=10, value=4, key="pain", label_visibility="collapsed")
+            st.markdown('<div class="field-label">Pain (0–10)</div>', unsafe_allow_html=True)
+            st.number_input("Pain", min_value=0, max_value=10, value=None, key="pain",
+                            placeholder="0–10", label_visibility="collapsed")
         with t_col:
             st.markdown('<div class="field-label">Arrival Transport</div>', unsafe_allow_html=True)
             st.selectbox("Transport", TRANSPORT_OPTIONS, key="arrival_transport", label_visibility="collapsed")
 
-    # ── Submit button (disabled while loading) ───────────────────
-    _l, center, _r = st.columns([2, 3, 2])
-    with center:
-        clicked = st.button(
-            "Analyzing..." if is_loading else "Run Triage Assessment",
-            type="primary",
-            use_container_width=True,
-            key="submit_btn",
-            disabled=is_loading,
-        )
+    # ── Submit button (hidden while loading via CSS overlay) ─────
+    if not is_loading:
+        _l, center, _r = st.columns([2, 3, 2])
+        with center:
+            clicked = st.button(
+                "Run Triage Assessment",
+                type="primary",
+                use_container_width=True,
+                key="submit_btn",
+            )
+    else:
+        clicked = False
 
-        # Status steps shown directly below the button
-        status_box = st.empty()
+    overlay_slot = st.empty()
 
     if clicked and not is_loading:
+        _sex_raw = st.session_state.get("sex", "—")
         form_data = {
             "first_name": st.session_state.get("first_name", ""),
             "last_name": st.session_state.get("last_name", ""),
-            "triage_notes": st.session_state.get("triage_notes", ""),
             "age": st.session_state.get("age"),
+            "sex": _sex_raw if _sex_raw != "—" else None,
+            "triage_notes": st.session_state.get("triage_notes", ""),
             "heart_rate": st.session_state.get("heart_rate"),
             "resp_rate": st.session_state.get("resp_rate"),
             "sbp": st.session_state.get("sbp"),
             "dbp": st.session_state.get("dbp"),
             "spo2": st.session_state.get("spo2"),
             "temp_f": st.session_state.get("temp_f"),
-            "pain": st.session_state.get("pain", 4),
+            "pain": st.session_state.get("pain"),
             "arrival_transport": st.session_state.get("arrival_transport", "Walk In"),
         }
         st.session_state.form_data = form_data
@@ -1007,7 +1082,7 @@ def render_intake_page():
         st.rerun()
 
     if is_loading:
-        _backend_keys = {"triage_notes", "age", "heart_rate", "resp_rate",
+        _backend_keys = {"triage_notes", "age", "sex", "heart_rate", "resp_rate",
                          "sbp", "dbp", "spo2", "temp_f", "pain", "arrival_transport"}
         form_data = st.session_state.get("form_data", {})
         payload = {k: v for k, v in form_data.items()
@@ -1027,32 +1102,39 @@ def render_intake_page():
         thread.start()
 
         steps = [
-            ("🔬", "Running ML model inference..."),
-            ("🔍", "Retrieving similar historical cases..."),
-            ("🧠", "LLM clinical analysis in progress..."),
-            ("📋", "Synthesizing triage recommendation..."),
+            ("🔬", "Running ML model inference"),
+            ("🔍", "Retrieving similar historical cases"),
+            ("🧠", "LLM clinical analysis"),
+            ("📋", "Synthesizing triage recommendation"),
         ]
-        step_idx = 0
-        while thread.is_alive():
-            icon, msg = steps[min(step_idx, len(steps) - 1)]
-            status_box.markdown(f"""
-            <div style="display:flex;align-items:center;gap:14px;padding:16px 20px;
-                        background:#f0f6ff;border-radius:10px;border:1px solid #c7d9f5;
-                        margin-top:12px;">
-                <div style="font-size:22px">{icon}</div>
-                <div>
-                    <div style="font-size:13px;font-weight:600;color:#1d4ed8;">{msg}</div>
-                    <div style="font-size:11px;color:#64748b;margin-top:2px;">
-                        Step {min(step_idx+1, len(steps))} of {len(steps)}
-                    </div>
+
+        def _render_overlay(current_idx):
+            rows = ""
+            for i, (icon, msg) in enumerate(steps):
+                if i < current_idx:
+                    rows += f'<div class="overlay-step step-done"><span class="overlay-step-icon">✓</span><span class="overlay-step-text">{msg}</span></div>'
+                elif i == current_idx:
+                    rows += f'<div class="overlay-step step-active"><span class="overlay-step-icon">{icon}</span><span class="overlay-step-text">{msg}…</span></div>'
+                else:
+                    rows += f'<div class="overlay-step step-pending"><span class="overlay-step-icon">{icon}</span><span class="overlay-step-text">{msg}</span></div>'
+            overlay_slot.markdown(f"""
+            <div class="triage-overlay">
+                <div class="triage-overlay-card">
+                    <div class="overlay-title">Analyzing Patient</div>
+                    <div class="overlay-subtitle">Running triage assessment pipeline…</div>
+                    {rows}
                 </div>
             </div>
             """, unsafe_allow_html=True)
+
+        step_idx = 0
+        while thread.is_alive():
+            _render_overlay(min(step_idx, len(steps) - 1))
             _time.sleep(4)
             step_idx += 1
 
         thread.join()
-        status_box.empty()
+        overlay_slot.empty()
         st.session_state.is_loading = False
 
         if "error" in result_holder:
@@ -1086,6 +1168,21 @@ def render_intake_page():
 # ── Page 2: Results ──────────────────────────────────────────────────────────
 
 def render_results_page():
+    st.markdown("""
+    <div class="top-header">
+        <div class="top-header-left">
+            <span class="brand-name">TriagePulse</span>
+            <div class="header-divider"></div>
+            <span class="page-title">Triage Assessment</span>
+        </div>
+        <div class="top-header-right">
+            <span class="header-icon">&#128276;</span>
+            <span class="header-icon">&#9881;</span>
+            <div class="avatar">&#128100;</div>
+        </div>
+    </div>
+    """, unsafe_allow_html=True)
+
     # Pull real data from session state — no mocks
     triage_result = st.session_state.get("triage_result", {})
     form_data = st.session_state.get("form_data", {})
@@ -1147,17 +1244,8 @@ def render_results_page():
 
     hdr_col, btn_col = st.columns([10, 2])
     with hdr_col:
-        st.markdown(f"""
-        <div style="background:#f8fafc;border:1px solid #dde3ed;border-radius:12px;
-                    padding:14px 20px;display:flex;align-items:center;gap:16px;">
-            <div style="font-size:26px;">&#128100;</div>
-            <div style="flex:1;">
-                <div style="font-size:14px;font-weight:700;color:#0f172a;">{patient_name}{age_str}</div>
-                <div style="font-size:12px;color:#64748b;margin-top:2px;">{notes_preview}{"..." if len(form_data.get("triage_notes","")) > 120 else ""}</div>
-            </div>
-            <div style="font-size:11px;color:#94a3b8;">{datetime.now(timezone.utc).strftime("%H:%M UTC")}</div>
-        </div>
-        """, unsafe_allow_html=True)
+        st.write(f"👤 **{patient_name}{age_str}**")
+        st.caption(notes_preview + ("..." if len(form_data.get("triage_notes", "")) > 120 else ""))
     with btn_col:
         if st.button("Triage Next Patient", type="primary", use_container_width=True, key="new_patient_btn"):
             for key in ["triage_notes", "age", "heart_rate", "resp_rate",
@@ -1169,6 +1257,16 @@ def render_results_page():
             st.rerun()
 
     # ── Triage decision card ──────────────────────────────────────
+    upgraded_html = f"""<div style="margin-top:10px;font-size:13px;color:{meta['color']};
+        background:{meta['badge_bg']};border-radius:8px;padding:10px 14px;">
+        ↑ <strong>Upgraded from initial assessment</strong> — clinical review flagged higher urgency
+    </div>""" if was_upgraded else ""
+
+    safety_html = f"""<div style="margin-top:10px;font-size:13px;color:#7c2d12;
+        background:#fff7ed;border:1px solid #fdba74;border-radius:8px;padding:10px 14px;">
+        ⚠️ <strong>Safety Alert:</strong> {safety_reason}
+    </div>""" if (safety_flag and safety_reason) else ""
+
     st.markdown(f"""
     <div style="background:{meta['bg']};border:1px solid {meta['border']};
                 border-left:6px solid {meta['color']};border-radius:12px;
@@ -1190,107 +1288,117 @@ def render_results_page():
             </div>
         </div>
     </div>
+    {upgraded_html}
+    {safety_html}
+    <div id="results-anchor"></div>
     """, unsafe_allow_html=True)
-
-    if was_upgraded:
-        st.markdown(f"""
-        <div style="margin-bottom:12px;font-size:13px;color:{meta['color']};
-                    background:{meta['badge_bg']};border-radius:8px;padding:10px 14px;">
-            ↑ <strong>Upgraded from initial assessment</strong> — clinical review flagged higher urgency
-        </div>
-        """, unsafe_allow_html=True)
-
-    if safety_flag and safety_reason:
-        st.markdown(f"""
-        <div style="margin-bottom:12px;font-size:13px;color:#7c2d12;
-                    background:#fff7ed;border:1px solid #fdba74;border-radius:8px;padding:10px 14px;">
-            ⚠️ <strong>Safety Alert:</strong> {safety_reason}
-        </div>
-        """, unsafe_allow_html=True)
+    # Force Streamlit out of the HTML context with a widget
+    st.empty()
 
     # ── Clinical reasoning ────────────────────────────────────────
     if clinical_rationale:
-        st.markdown(f"""
-        <div class="rationale-section">
-            <div class="confidence-title">Clinical Reasoning</div>
-            <div class="rationale-text">{clinical_rationale}</div>
-        </div>
-        """, unsafe_allow_html=True)
+        st.divider()
+        st.subheader("Clinical Reasoning")
+        st.write(clinical_rationale)
 
-    # ── Key vitals that drove the decision (from SHAP, plain English) ──
-    if top_features:
-        vital_rows = ""
-        for f in top_features:
-            name = FEATURE_DISPLAY_NAMES.get(f.get("feature", ""), f.get("feature", "").replace("_", " ").title())
-            direction = f.get("direction", "")
-            shap = f.get("shap", 0)
-            is_against = "away" in direction
-            tag_color  = "#b91c1c" if is_against else "#15803d"
-            tag_bg     = "#fee2e2" if is_against else "#dcfce7"
-            tag_text   = "Working against this level" if is_against else "Supporting this level"
-            vital_rows += f"""
-            <tr>
-                <td style="font-weight:600;color:#0f172a;">{name}</td>
-                <td><span style="background:{tag_bg};color:{tag_color};font-size:11px;
-                                 font-weight:600;padding:2px 8px;border-radius:4px;">
-                    {tag_text}
-                </span></td>
-            </tr>"""
-        st.markdown(f"""
-        <div class="rationale-section" style="margin-top:16px;">
-            <div class="confidence-title">Key Factors</div>
-            <table style="width:100%;border-collapse:collapse;font-size:13px;">
-                <tbody>{vital_rows}</tbody>
-            </table>
-        </div>
-        """, unsafe_allow_html=True)
+    # ── Key factors + Similar cases side by side ─────────────────
+    st.divider()
+    left_col, right_col = st.columns(2)
 
-    # ── Similar past cases ────────────────────────────────────────
-    if similar_cases:
-        URGENCY_LABEL = {1: "Critical", 2: "Emergent", 3: "Urgent"}
-        URGENCY_COLOR = {1: "#b91c1c", 2: "#c2410c", 3: "#a16207"}
-        URGENCY_BG    = {1: "#fee2e2", 2: "#ffedd5", 3: "#fef9c3"}
-        rows = ""
-        for c in similar_cases:
-            esi = c.get("triage_level")
-            urgency_label = URGENCY_LABEL.get(esi, "Unknown")
-            urg_color = URGENCY_COLOR.get(esi, "#64748b")
-            urg_bg    = URGENCY_BG.get(esi, "#f1f5f9")
-            outcome   = (c.get("outcome") or "—").title()
-            complaint = (c.get("chief_complaint") or "—").title()
-            diagnosis = (c.get("diagnosis") or "—").title()
-            rows += f"""
-            <tr style="border-bottom:1px solid #f1f5f9;">
-                <td style="padding:10px;font-weight:600;color:#0f172a;">{complaint}</td>
-                <td style="padding:10px;color:#475569;">{diagnosis}</td>
-                <td style="padding:10px;">
-                    <span style="background:{urg_bg};color:{urg_color};font-size:11px;
-                                 font-weight:700;padding:2px 8px;border-radius:4px;">
-                        ESI {esi} — {urgency_label}
-                    </span>
-                </td>
-                <td style="padding:10px;color:#475569;">{outcome}</td>
-            </tr>"""
-        st.markdown(f"""
-        <div class="cases-section">
-            <div class="confidence-title">Similar Past Cases</div>
-            <table style="width:100%;border-collapse:collapse;font-size:13px;">
-                <thead>
-                    <tr style="border-bottom:2px solid #e2e8f0;">
-                        <th style="text-align:left;padding:8px 10px;font-size:10px;font-weight:700;
-                                   text-transform:uppercase;letter-spacing:1px;color:#64748b;">Chief Complaint</th>
-                        <th style="text-align:left;padding:8px 10px;font-size:10px;font-weight:700;
-                                   text-transform:uppercase;letter-spacing:1px;color:#64748b;">Diagnosis</th>
-                        <th style="text-align:left;padding:8px 10px;font-size:10px;font-weight:700;
-                                   text-transform:uppercase;letter-spacing:1px;color:#64748b;">ESI Level</th>
-                        <th style="text-align:left;padding:8px 10px;font-size:10px;font-weight:700;
-                                   text-transform:uppercase;letter-spacing:1px;color:#64748b;">Outcome</th>
-                    </tr>
-                </thead>
-                <tbody>{rows}</tbody>
-            </table>
-        </div>
-        """, unsafe_allow_html=True)
+    with left_col:
+        st.subheader("Key Factors")
+        if top_features:
+            rows = ""
+            for f in top_features:
+                name = FEATURE_DISPLAY_NAMES.get(f.get("feature", ""), f.get("feature", "").replace("_", " ").title())
+                is_against = "away" in f.get("direction", "")
+                tag_color = "#b91c1c" if is_against else "#15803d"
+                tag_bg    = "#fee2e2" if is_against else "#dcfce7"
+                tag_text  = "⬆ Working against" if is_against else "⬇ Supporting"
+                rows += f"""<tr style="border-bottom:1px solid #f1f5f9;">
+                    <td style="padding:8px 4px;font-weight:600;font-size:13px;color:#0f172a;">{name}</td>
+                    <td style="padding:8px 4px;">
+                        <span style="background:{tag_bg};color:{tag_color};font-size:11px;
+                                     font-weight:600;padding:2px 8px;border-radius:4px;">{tag_text}</span>
+                    </td>
+                </tr>"""
+            st.markdown(f'<table style="width:100%;border-collapse:collapse;">{rows}</table>', unsafe_allow_html=True)
+            st.empty()
+        else:
+            st.caption("No key factors available.")
+
+    with right_col:
+        st.subheader("Similar Past Cases")
+        if not similar_cases:
+            st.caption("No similar cases retrieved.")
+        else:
+            URGENCY_LABEL = {1: "Critical", 2: "Emergent", 3: "Urgent"}
+            URGENCY_COLOR = {1: "#b91c1c", 2: "#c2410c", 3: "#a16207"}
+            URGENCY_BG    = {1: "#fee2e2", 2: "#ffedd5", 3: "#fef9c3"}
+            rows = ""
+            for c in similar_cases:
+                esi           = c.get("triage_level")
+                urgency_label = URGENCY_LABEL.get(esi, "Unknown")
+                urg_color     = URGENCY_COLOR.get(esi, "#64748b")
+                urg_bg        = URGENCY_BG.get(esi, "#f1f5f9")
+                outcome       = (c.get("outcome") or "—").title()
+                complaint     = (c.get("chief_complaint") or "—").title()
+                diagnosis     = (c.get("diagnosis") or "—").title()
+                similarity    = c.get("similarity")
+                sim_str       = f" · {int(similarity * 100)}% match" if similarity is not None else ""
+                vitals_parts  = []
+                if c.get("heart_rate"): vitals_parts.append(f"HR {c['heart_rate']}")
+                if c.get("sbp"):        vitals_parts.append(f"SBP {c['sbp']}")
+                if c.get("spo2"):       vitals_parts.append(f"SpO₂ {c['spo2']}%")
+                vitals_str = "  ·  ".join(vitals_parts)
+                patient_info = (c.get("patient_info") or "").replace("Gender: ", "").replace("Race: ", "").replace("Age: ", "")
+                rows += f"""<tr style="border-bottom:1px solid #f1f5f9;">
+                    <td style="padding:8px 4px;">
+                        <div style="font-weight:600;font-size:13px;color:#0f172a;">{complaint}</div>
+                        <div style="font-size:11px;color:#475569;margin-top:2px;">{patient_info}</div>
+                        <div style="font-size:11px;color:#64748b;margin-top:2px;">{diagnosis}{sim_str}</div>
+                        <div style="font-size:11px;color:#94a3b8;margin-top:2px;">{vitals_str}</div>
+                    </td>
+                    <td style="padding:8px 4px;white-space:nowrap;">
+                        <span style="background:{urg_bg};color:{urg_color};font-size:11px;
+                                     font-weight:700;padding:2px 8px;border-radius:4px;">ESI {esi} — {urgency_label}</span>
+                        <div style="font-size:11px;color:#94a3b8;margin-top:4px;">{outcome}</div>
+                    </td>
+                </tr>"""
+            st.markdown(f'<table style="width:100%;border-collapse:collapse;">{rows}</table>', unsafe_allow_html=True)
+            st.empty()
+
+    # ── Technical info card ───────────────────────────────────────────────────
+    LLM_ESI_LABEL_MAP = {
+        1: "ESI 1 — Critical",
+        2: "ESI 2 — Emergent",
+        3: "ESI 3 — Urgent/Less Urgent",
+    }
+
+    model_label    = triage_result.get("predicted_label", "—")
+    model_conf     = triage_result.get("confidence_pct")
+    model_conf_str = f"{model_conf}% confidence" if model_conf is not None else ""
+    llm_esi        = triage_result.get("llm_esi")
+    llm_label      = LLM_ESI_LABEL_MAP.get(llm_esi, "—")
+    reconciled     = triage_result.get("reconciled_label") or "—"
+    llm_agreement  = triage_result.get("llm_agreement")
+    agreement_str  = "Agreement" if llm_agreement else "Override"
+
+    st.divider()
+    st.subheader("Technical Details")
+    t1, t2, t3 = st.columns(3)
+    with t1:
+        st.caption("arch4 Model")
+        st.write(f"**{model_label}**")
+        if model_conf_str:
+            st.caption(model_conf_str)
+    with t2:
+        st.caption("LLM Independent")
+        st.write(f"**{llm_label}**")
+        st.caption(agreement_str)
+    with t3:
+        st.caption("Reconciled Result")
+        st.write(f"**{reconciled}**")
 
 
 # ── Main ──────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
- Wired the LangGraph agentic pipeline into /predict — requests now run predict_node (SageMaker) + retrieve_node (Pinecone RAG) in parallel, fan into analyze_node (Claude Sonnet via Bedrock), then synthesize_node for reconciliation
- Extended TriageResponse with enriched fields: reconciled label, LLM ESI, clinical rationale, similar cases, flags, confidence
- Added sex to intake form and patient dict for LLM/RAG context
- Redesigned Streamlit frontend: clean intake form, nurse-friendly results page with ESI priority card, clinical reasoning, key SHAP factors (plain English tags), similar past cases with vitals + demographics, technical details card (model vs LLM vs reconciled)
- Full-screen loading overlay with animated step progress while pipeline runs
- Updated ORCHESTRATION.md to reflect completed integration